### PR TITLE
Keep players from falling through moving frames

### DIFF
--- a/technic/frames.lua
+++ b/technic/frames.lua
@@ -364,7 +364,6 @@ function move_nodes_vect(poslist,vect)
 		local node=minetest.env:get_node(pos)
 		local meta=minetest.env:get_meta(pos):to_table()
 		nodelist[#(nodelist)+1]={pos=pos,node=node,meta=meta}
-		minetest.env:remove_node(pos)
 	end
 	objects={}
 	for _,pos in ipairs(poslist) do
@@ -384,6 +383,15 @@ function move_nodes_vect(poslist,vect)
 		minetest.env:set_node(npos,n.node)
 		local meta=minetest.env:get_meta(npos)
 		meta:from_table(n.meta)
+		for __,pos in ipairs(poslist) do
+			if npos.x==pos.x and npos.y==pos.y and npos.z==pos.z then
+				table.remove(poslist, __)
+				break
+			end
+		end
+	end
+	for __,pos in ipairs(poslist) do
+		minetest.env:remove_node(pos)
 	end
 end
 


### PR DESCRIPTION
Before, when a frame moved, it removed the whole thing, then reappeared in its new location. If it takes any time at all to do this, a player will fall while the machine doesn't exist, then be stuck inside the machine or completely under it when it reappears.
Now, when a frame moves, it creates a copy in its new location, then removes any part of the original that wasn't overwritten by the copy. This way, the machine still exists, and a wave of duplication goes through it, followed by a wave of deletion.

Here's a textual demonstration:

P represents the player, other letters represent frames and nodes moved by frames, and - represents the ground.

```
Before:

----
 P
ABCD

----

 P
ABC

----
 P
AB

----
 P
A

----

 P

----

    D
 P
----

   CD
 P
----

  BCD
 P
----

 ABCD
 P
----
```

```
After:

----
 P
ABCD

----
 P
ABCDD

----
 P
ABCCD

----
 P
ABBCD

----
 P
AABCD

----
 P
 ABCD

----
```
