### PR TITLE
Externalised common functions of the mv mashines.

### DIFF
--- a/technic/machines/mv/alloy_furnace.lua
+++ b/technic/machines/mv/alloy_furnace.lua
@@ -25,19 +25,8 @@ minetest.register_node(
     tiles = {"technic_mv_alloy_furnace_top.png", "technic_mv_alloy_furnace_bottom.png", "technic_mv_alloy_furnace_side_tube.png",
 	     "technic_mv_alloy_furnace_side_tube.png", "technic_mv_alloy_furnace_side.png", "technic_mv_alloy_furnace_front.png"},
     paramtype2 = "facedir",
-    groups = {cracky=2, tubedevice=1,tubedevice_receiver=1},
-    tube={insert_object=function(pos,node,stack,direction)
-			   local meta=minetest.env:get_meta(pos)
-			   local inv=meta:get_inventory()
-			   return inv:add_item("src",stack)
-			end,
-	  can_insert=function(pos,node,stack,direction)
-			local meta=minetest.env:get_meta(pos)
-			local inv=meta:get_inventory()
-			return inv:room_for_item("src",stack)
-		     end,
-		connect_sides = {left=1, right=1, back=1, top=1, bottom=1},
-       },
+    groups = technic.mv_groups_inactive,
+    tube = technic.mv_tube_definitions,
     legacy_facedir_simple = true,
     sounds = default.node_sound_stone_defaults(),
     on_construct = function(pos)
@@ -52,16 +41,7 @@ minetest.register_node(
 		      inv:set_size("upgrade1", 1)
 		      inv:set_size("upgrade2", 1)
 		   end,
-    can_dig = function(pos,player)
-		 local meta = minetest.env:get_meta(pos);
-		 local inv = meta:get_inventory()
-		 if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
-		    minetest.chat_send_player(player:get_player_name(), "Machine cannot be removed because it is not empty");
-		    return false
-		 else
-		    return true
-		 end
-	      end,
+    can_dig = technic.mv_can_dig,
 })
 
 minetest.register_node(
@@ -72,31 +52,11 @@ minetest.register_node(
     paramtype2 = "facedir",
     light_source = 8,
     drop = "technic:mv_alloy_furnace",
-    groups = {cracky=2, tubedevice=1,tubedevice_receiver=1,not_in_creative_inventory=1},
-    tube={insert_object=function(pos,node,stack,direction)
-			   local meta=minetest.env:get_meta(pos)
-			   local inv=meta:get_inventory()
-			   return inv:add_item("src",stack)
-			end,
-	  can_insert=function(pos,node,stack,direction)
-			local meta=minetest.env:get_meta(pos)
-			local inv=meta:get_inventory()
-			return inv:room_for_item("src",stack)
-		     end,
-		connect_sides = {left=1, right=1, back=1, top=1, bottom=1},
-       },
+    groups = technic.mv_groups_active,
+    tube = technic.mv_tube_definitions,
     legacy_facedir_simple = true,
     sounds = default.node_sound_stone_defaults(),
-    can_dig = function(pos,player)
-		 local meta = minetest.env:get_meta(pos);
-		 local inv = meta:get_inventory()
-		 if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
-		    minetest.chat_send_player(player:get_player_name(), "Machine cannot be removed because it is not empty");
-		    return false
-		 else
-		    return true
-		 end
-	      end,
+    can_dig = technic.mv_can_dig,
     -- These three makes sure upgrades are not moved in or out while the furnace is active.
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 				       if listname == "src" or listname == "dst" then
@@ -116,29 +76,6 @@ minetest.register_node(
 				    return 0
 				 end,
 })
-
-local send_cooked_items = function(pos,x_velocity,z_velocity)
-			     -- Send items on their way in the pipe system.
-			     local meta=minetest.env:get_meta(pos) 
-			     local inv = meta:get_inventory()
-			     local i=0
-			     for _,stack in ipairs(inv:get_list("dst")) do
-				i=i+1
-				if stack then
-				   local item0=stack:to_table()
-				if item0 then 
-				   item0["count"]="1"
-				   local item1=tube_item({x=pos.x,y=pos.y,z=pos.z},item0)
-				   item1:get_luaentity().start_pos = {x=pos.x,y=pos.y,z=pos.z}
-				   item1:setvelocity({x=x_velocity, y=0, z=z_velocity})
-				   item1:setacceleration({x=0, y=0, z=0})
-				   stack:take_item(1);
-				   inv:set_stack("dst", i, stack)
-				   return
-				end
-			     end
-			  end
-		       end
 
 local smelt_item = function(pos)
 		      local meta=minetest.env:get_meta(pos) 
@@ -255,7 +192,7 @@ minetest.register_abm(
 		   if tube_time > 3 then
 		      tube_time = 0
 		      if output_tube_connected then
-			 send_cooked_items(pos,x_velocity,z_velocity)
+			 technic.mv_send_tube_items(pos,x_velocity,z_velocity)
 		      end
 		   end
 		   meta:set_int("tube_time", tube_time)

--- a/technic/machines/mv/common.lua
+++ b/technic/machines/mv/common.lua
@@ -1,0 +1,62 @@
+technic.mv_can_dig =
+	function(pos, player)
+		local meta = minetest.env:get_meta(pos);
+		local inv = meta:get_inventory()
+		if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
+			minetest.chat_send_player(player:get_player_name(), "Machine cannot be removed because it is not empty");
+			return false
+		else
+			return true
+		end
+	end
+
+technic.mv_send_tube_items =
+	function(pos,x_velocity,z_velocity)
+		-- Send items on their way in the pipe system.
+		local meta=minetest.env:get_meta(pos) 
+		local inv = meta:get_inventory()
+		local i=0
+		for _,stack in ipairs(inv:get_list("dst")) do
+			i=i+1
+			if stack then
+				local item0=stack:to_table()
+				if item0 then
+					item0["count"]="1"
+					local item1=tube_item({x=pos.x,y=pos.y,z=pos.z},item0)
+					item1:get_luaentity().start_pos = {x=pos.x,y=pos.y,z=pos.z}
+					item1:setvelocity({x=x_velocity, y=0, z=z_velocity})
+					item1:setacceleration({x=0, y=0, z=0})
+					stack:take_item(1);
+					inv:set_stack("dst", i, stack)
+					return
+				end
+			end
+		end
+	end
+
+technic.mv_tube_definitions = {
+	insert_object=function(pos,node,stack,direction)
+		local meta=minetest.env:get_meta(pos)
+		local inv=meta:get_inventory()
+		return inv:add_item("src",stack)
+	end,
+	can_insert=function(pos,node,stack,direction)
+		local meta=minetest.env:get_meta(pos)
+		local inv=meta:get_inventory()
+		return inv:room_for_item("src",stack)
+	end,
+	connect_sides = {left = 1, right = 1, back = 1, top = 1, bottom = 1},
+}
+
+technic.mv_groups_inactive = {
+	cracky = 2,
+	tubedevice = 1,
+	tubedevice_receiver = 1
+}
+
+technic.mv_groups_active = {
+	cracky = 2,
+	tubedevice = 1,
+	tubedevice_receiver = 1,
+	not_in_creative_inventory = 1,
+}

--- a/technic/machines/mv/electric_furnace.lua
+++ b/technic/machines/mv/electric_furnace.lua
@@ -30,19 +30,8 @@ minetest.register_node(
     tiles = {"technic_mv_electric_furnace_top.png", "technic_mv_electric_furnace_bottom.png", "technic_mv_electric_furnace_side_tube.png",
 	     "technic_mv_electric_furnace_side_tube.png", "technic_mv_electric_furnace_side.png", "technic_mv_electric_furnace_front.png"},
     paramtype2 = "facedir",
-    groups = {cracky=2, tubedevice=1,tubedevice_receiver=1,},
-    tube={insert_object=function(pos,node,stack,direction)
-			   local meta=minetest.env:get_meta(pos)
-			   local inv=meta:get_inventory()
-			   return inv:add_item("src",stack)
-			end,
-	  can_insert=function(pos,node,stack,direction)
-			local meta=minetest.env:get_meta(pos)
-			local inv=meta:get_inventory()
-			return inv:room_for_item("src",stack)
-		     end,
-		connect_sides = {left=1, right=1, back=1, top=1, bottom=1},
-       },
+    groups = technic.mv_groups_inactive,
+    tube = technic.mv_tube_definitions,
     legacy_facedir_simple = true,
     sounds = default.node_sound_stone_defaults(),
     on_construct = function(pos)
@@ -57,16 +46,7 @@ minetest.register_node(
 		      inv:set_size("upgrade1", 1)
 		      inv:set_size("upgrade2", 1)
 		   end,
-    can_dig = function(pos,player)
-		 local meta = minetest.env:get_meta(pos);
-		 local inv = meta:get_inventory()
-		 if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
-		    minetest.chat_send_player(player:get_player_name(), "Machine cannot be removed because it is not empty");
-		    return false
-		 else
-		    return true
-		 end
-	      end,
+    can_dig = technic.mv_can_dig,
  })
 
 minetest.register_node(
@@ -77,31 +57,11 @@ minetest.register_node(
     paramtype2 = "facedir",
     light_source = 8,
     drop = "technic:mv_electric_furnace",
-    groups = {cracky=2, tubedevice=1,tubedevice_receiver=1,not_in_creative_inventory=1},
-    tube={insert_object=function(pos,node,stack,direction)
-			   local meta=minetest.env:get_meta(pos)
-			   local inv=meta:get_inventory()
-			   return inv:add_item("src",stack)
-			end,
-	  can_insert=function(pos,node,stack,direction)
-			local meta=minetest.env:get_meta(pos)
-			local inv=meta:get_inventory()
-			return inv:room_for_item("src",stack)
-		     end,
-		connect_sides = {left=1, right=1, back=1, top=1, bottom=1},
-       },
+    groups = technic.mv_groups_active,
+    tube = technic.mv_tube_definitions,
     legacy_facedir_simple = true,
     sounds = default.node_sound_stone_defaults(),
-    can_dig = function(pos,player)
-		 local meta = minetest.env:get_meta(pos);
-		 local inv = meta:get_inventory()
-		 if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
-		    minetest.chat_send_player(player:get_player_name(), "Machine cannot be removed because it is not empty");
-		    return false
-		 else
-		    return true
-		 end
-	      end,
+    can_dig = technic.mv_can_dig,
     -- These three makes sure upgrades are not moved in or out while the furnace is active.
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 				       if listname == "src" or listname == "dst" then
@@ -121,29 +81,6 @@ minetest.register_node(
 				    return 0
 				 end,
  })
-
-local send_cooked_items = function(pos,x_velocity,z_velocity)
-			     -- Send items on their way in the pipe system.
-			     local meta=minetest.env:get_meta(pos) 
-			     local inv = meta:get_inventory()
-			     local i=0
-			     for _,stack in ipairs(inv:get_list("dst")) do
-				i=i+1
-				if stack then
-				   local item0=stack:to_table()
-				if item0 then 
-				   item0["count"]="1"
-				   local item1=tube_item({x=pos.x,y=pos.y,z=pos.z},item0)
-				   item1:get_luaentity().start_pos = {x=pos.x,y=pos.y,z=pos.z}
-				   item1:setvelocity({x=x_velocity, y=0, z=z_velocity})
-				   item1:setacceleration({x=0, y=0, z=0})
-				   stack:take_item(1);
-				   inv:set_stack("dst", i, stack)
-				   return
-				end
-			     end
-			  end
-		       end
 
 local smelt_item = function(pos)
 		      local meta=minetest.env:get_meta(pos) 
@@ -255,7 +192,7 @@ minetest.register_abm(
 		   if tube_time > 3 then
 		      tube_time = 0
 		      if output_tube_connected then
-			 send_cooked_items(pos,x_velocity,z_velocity)
+			 technic.mv_send_tube_items(pos,x_velocity,z_velocity)
 		      end
 		   end
 		   meta:set_int("tube_time", tube_time)

--- a/technic/machines/mv/grinder.lua
+++ b/technic/machines/mv/grinder.lua
@@ -30,19 +30,8 @@ minetest.register_node(
 	tiles = {"technic_mv_grinder_top.png", "technic_mv_grinder_bottom.png", "technic_mv_grinder_side.png",
 			"technic_mv_grinder_side.png", "technic_mv_grinder_side.png", "technic_mv_grinder_front.png"},
 	paramtype2 = "facedir",
-	groups = {cracky=2, tubedevice=1,tubedevice_receiver=1,},
-	tube={insert_object=function(pos,node,stack,direction)
-			local meta=minetest.env:get_meta(pos)
-			local inv=meta:get_inventory()
-			return inv:add_item("src",stack)
-		end,
-		can_insert=function(pos,node,stack,direction)
-			local meta=minetest.env:get_meta(pos)
-			local inv=meta:get_inventory()
-			return inv:room_for_item("src",stack)
-		end,
-		connect_sides = {left=1, right=1, back=1, top=1, bottom=1},
-	},
+	groups = technic.mv_groups_inactive,
+	tube = technic.mv_tube_definitions,
 	legacy_facedir_simple = true,
 	sounds = default.node_sound_wood_defaults(),
 	on_construct = function(pos)
@@ -57,16 +46,7 @@ minetest.register_node(
 		inv:set_size("upgrade1", 1)
 		inv:set_size("upgrade2", 1)
 	end,
-	can_dig = function(pos,player)
-		local meta = minetest.env:get_meta(pos);
-		local inv = meta:get_inventory()
-		if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
-			minetest.chat_send_player(player:get_player_name(), "Machine cannot be removed because it is not empty");
-			return false
-		else
-			return true
-		end
-	end,
+	can_dig = technic.mv_can_dig,
 })
 
 minetest.register_node(
@@ -76,31 +56,11 @@ minetest.register_node(
 		tiles = {"technic_mv_grinder_top.png", "technic_mv_grinder_bottom.png", "technic_mv_grinder_side.png",
 			"technic_mv_grinder_side.png", "technic_mv_grinder_side.png", "technic_mv_grinder_front_active.png"},
 		paramtype2 = "facedir",
-		groups = {cracky=2,tubedevice=1,tubedevice_receiver=1,not_in_creative_inventory=1},
-		tube={	insert_object=function(pos,node,stack,direction)
-				local meta=minetest.env:get_meta(pos)
-				local inv=meta:get_inventory()
-				return inv:add_item("src",stack)
-			end,
-			can_insert=function(pos,node,stack,direction)
-				local meta=minetest.env:get_meta(pos)
-				local inv=meta:get_inventory()
-				return inv:room_for_item("src",stack)
-			end,
-			connect_sides = {left=1, right=1, back=1, top=1, bottom=1},
-		},
+		groups = technic.mv_groups_active,
+		tube = technic.mv_tube_definitions,
 		legacy_facedir_simple = true,
 		sounds = default.node_sound_wood_defaults(),
-		can_dig = function(pos,player)
-			local meta = minetest.env:get_meta(pos);
-			local inv = meta:get_inventory()
-			if not inv:is_empty("src") or not inv:is_empty("dst") or not inv:is_empty("upgrade1") or not inv:is_empty("upgrade2") then
-				minetest.chat_send_player(player:get_player_name(), "Machine cannot be removed because it is not empty");
-				return false
-			else
-				return true
-			end
-		end,
+		can_dig = technic.mv_can_dig,
 		-- These three makes sure upgrades are not moved in or out while the grinder is active.
 		allow_metadata_inventory_put = function(pos, listname, index, stack, player)
 			if listname == "src" or listname == "dst" then
@@ -120,29 +80,6 @@ minetest.register_node(
 			return 0
 		end,
 	})
-
-local send_grinded_items = function(pos,x_velocity,z_velocity)
-	-- Send items on their way in the pipe system.
-	local meta=minetest.env:get_meta(pos) 
-	local inv = meta:get_inventory()
-	local i=0
-	for _,stack in ipairs(inv:get_list("dst")) do
-		i=i+1
-		if stack then
-			local item0=stack:to_table()
-			if item0 then 
-				item0["count"]="1"
-				local item1=tube_item({x=pos.x,y=pos.y,z=pos.z},item0)
-				item1:get_luaentity().start_pos = {x=pos.x,y=pos.y,z=pos.z}
-				item1:setvelocity({x=x_velocity, y=0, z=z_velocity})
-				item1:setacceleration({x=0, y=0, z=0})
-				stack:take_item(1);
-				inv:set_stack("dst", i, stack)
-				return
-			end
-		end
-	end
-end
 
 minetest.register_abm(
 	{ nodenames = {"technic:mv_grinder","technic:mv_grinder_active"},
@@ -232,7 +169,7 @@ minetest.register_abm(
 			if tube_time > 3 then
 				tube_time = 0
 				if output_tube_connected then
-					send_grinded_items(pos,x_velocity,z_velocity)
+					technic.mv_send_tube_items(pos,x_velocity,z_velocity)
 				end
 			end
 			meta:set_int("tube_time", tube_time)

--- a/technic/machines/mv/init.lua
+++ b/technic/machines/mv/init.lua
@@ -3,6 +3,7 @@ local path = technic.modpath.."/machines/mv"
 dofile(path.."/wires.lua")
 dofile(path.."/battery_box.lua")
 dofile(path.."/solar_array.lua")
+dofile(path.."/common.lua")
 dofile(path.."/electric_furnace.lua")
 dofile(path.."/alloy_furnace.lua")
 dofile(path.."/grinder.lua")


### PR DESCRIPTION
This avoids code duplications and helps to define new mv mashines
