### PR TITLE
Fixed music player

### DIFF
--- a/technic/machines/LV/music_player.lua
+++ b/technic/machines/LV/music_player.lua
@@ -32,7 +32,7 @@ local music_player_formspec =
 	"label[4,0;Current track --]"
 
 local function play_track(pos, track)
-	return minetest.sound_play("technic_track"..track,
+	return minetest.sound_play("technic_track"..tostring(track),
 			{pos = pos, gain = 1.0, loop = true, max_hear_distance = 72,})
 end
 


### PR DESCRIPTION
A tostring was missing, and therefore it wouldn't play any music. It didn't work at all for me before, but now it plays music just fine from (root)/technic/sounds/ where the file name is technic_track#.ogg, where # is a number from 1 to 9.
