### PR TITLE
Generators must stop supplying when fuel runs out but non-fuel items exist in fuel slot

### DIFF
--- a/technic/machines/register/generator.lua
+++ b/technic/machines/register/generator.lua
@@ -59,6 +59,7 @@ function technic.register_generator(data)
 				if not fuel or fuel.time == 0 then
 					meta:set_string("infotext", S("%s Out Of Fuel"):format(desc))
 					technic.swap_node(pos, "technic:"..ltier.."_generator")
+					meta:set_int(tier.."_EU_supply", 0)
 					return
 				end
 				meta:set_int("burn_time", fuel.time)


### PR DESCRIPTION
Fixes minetest-technic/technic#156
