### PR TITLE
Removed extra register of LV Transformer

### DIFF
--- a/technic/items.lua
+++ b/technic/items.lua
@@ -100,10 +100,6 @@ minetest.register_craftitem("technic:lv_transformer", {
 	inventory_image = "technic_lv_transformer.png",
 })
 
-minetest.register_craftitem("technic:lv_transformer", {
-	description = S("Low Voltage Transformer"),
-	inventory_image = "technic_lv_transformer.png",
-})
 minetest.register_craftitem("technic:mv_transformer", {
 	description = S("Medium Voltage Transformer"),
 	inventory_image = "technic_mv_transformer.png",


### PR DESCRIPTION
I was browsing the code and saw LV transformer registered twice in a row. Excuse my ignorance if there was reason for what I thought was a duplicate.
