### PR TITLE
make solar arrays only work with sunlight

### DIFF
--- a/technic/machines/register/solar_array.lua
+++ b/technic/machines/register/solar_array.lua
@@ -1,17 +1,17 @@
 
 local S = technic.getter
 
+local function get_light(param1)
+	local alight = (param1-param1%16)/16
+	local sunlight = (param1%16 ~= alight and param1%16) or 0
+	return sunlight, alight
+end
+
 function technic.register_solar_array(data)
 	local tier = data.tier
 	local ltier = string.lower(tier)
 
-	local run = function(pos, node)
-		-- The action here is to make the solar array produce power
-		-- Power is dependent on the light level and the height above ground
-		-- There are many ways to cheat by using other light sources like lamps.
-		-- As there is no way to determine if light is sunlight that is just a shame.
-		-- To take care of some of it solar panels do not work outside daylight hours or if
-		-- built below 0m
+	local function run(pos, node)
 		local pos1 = {}
 		local machine_name = S("Arrayed Solar %s Generator"):format(tier)
 		pos1.y = pos.y + 1
@@ -19,14 +19,12 @@ function technic.register_solar_array(data)
 		pos1.z = pos.z
 
 		technic.get_or_load_node(pos1)
-		local light = minetest.get_node_light(pos1, nil)
+		local light = get_light(node.param1)
 		local time_of_day = minetest.get_timeofday()
 		local meta = minetest.get_meta(pos)
-		light = light or 0
 
 		-- turn on array only during day time and if sufficient light
-		-- I know this is counter intuitive when cheating by using other light sources.
-		if light >= 12 and time_of_day >= 0.24 and time_of_day <= 0.76 and pos.y > 0 then
+		if light >= 12 and time_of_day >= 0.24 and time_of_day <= 0.76 then
 			local charge_to_give = math.floor((light + pos.y) * data.power)
 			charge_to_give = math.max(charge_to_give, 0)
 			charge_to_give = math.min(charge_to_give, data.power * 50)
@@ -37,7 +35,7 @@ function technic.register_solar_array(data)
 			meta:set_int(tier.."_EU_supply", 0)
 		end
 	end
-	
+
 	minetest.register_node("technic:solar_array_"..ltier, {
 		tiles = {"technic_"..ltier.."_solar_array_top.png",  "technic_"..ltier.."_solar_array_bottom.png",
 			 "technic_"..ltier.."_solar_array_side.png", "technic_"..ltier.."_solar_array_side.png",


### PR DESCRIPTION
This uses `param1` instead of `minetest.get_node_light(pos1, nil)`.
Also this allows to have solar arrays beyond 0, but that's no real problem since they are there very inefficient.
I don't know, why this hasn't been done yet.