### PR TITLE
Add the sapling group to rubber_tree_sapling

### DIFF
--- a/technic_worldgen/rubber.lua
+++ b/technic_worldgen/rubber.lua
@@ -10,7 +10,7 @@ minetest.register_node(":moretrees:rubber_tree_sapling", {
 	wield_image = "technic_rubber_sapling.png",
 	paramtype = "light",
 	walkable = false,
-	groups = {dig_immediate=3, flammable=2},
+	groups = {dig_immediate=3, flammable=2, sapling=1},
 	sounds = default.node_sound_defaults(),
 })
 
@@ -98,4 +98,3 @@ if technic.config:get_bool("enable_rubber_tree_generation") then
 		end
 	end)
 end
-


### PR DESCRIPTION
 > Add the sapling group to Rubber Tree Sapling so that it can be used in
 > Mesecons recipes for glue and blinky plant.

The Rubber Tree Sapling that comes with Technic can't be used for much besides planting more Rubber Trees. So, you end up with a lot more saplings then you'll ever need trees.

I added the sapling group to the node so that it can be cooked to create glue or used with mesecon wires to create blinky plants. This should also allow it to be used as fuel in minetest_game.