### PR TITLE
Test 'have_ui' before calling 'unified_inventory' global

### DIFF
--- a/technic/machines/register/recipes.lua
+++ b/technic/machines/register/recipes.lua
@@ -51,7 +51,7 @@ local function register_recipe(typename, data)
 	end
 	
 	technic.recipes[typename].recipes[index] = recipe
-	if unified_inventory and technic.recipes[typename].output_size == 1 then
+	if have_ui and technic.recipes[typename].output_size == 1 then
 		unified_inventory.register_craft({
 			type = typename,
 			output = data.output,


### PR DESCRIPTION
Not sure if I did this right, but it fixes 'Undeclared global variable "unified_inventory"' warning.