### PR TITLE
Replace deprecated method 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/technic/init.lua
+++ b/technic/init.lua
@@ -5,7 +5,7 @@
 local load_start = os.clock()
 
 technic = rawget(_G, "technic") or {}
-technic.creative_mode = minetest.setting_getbool("creative_mode")
+technic.creative_mode = minetest.settings:get_bool("creative_mode")
 
 
 local modpath = minetest.get_modpath("technic")
@@ -47,7 +47,7 @@ dofile(modpath.."/tools/init.lua")
 -- Aliases for legacy node/item names
 dofile(modpath.."/legacy.lua")
 
-if minetest.setting_getbool("log_mods") then
+if minetest.settings:get_bool("log_mods") then
 	print(S("[Technic] Loaded in %f seconds"):format(os.clock() - load_start))
 end
 

--- a/technic/machines/other/frames.lua
+++ b/technic/machines/other/frames.lua
@@ -3,7 +3,7 @@ local S = technic.getter
 
 frames = {}
 
-local infinite_stacks = minetest.setting_getbool("creative_mode") and minetest.get_modpath("unified_inventory") == nil
+local infinite_stacks = minetest.settings:get_bool("creative_mode") and minetest.get_modpath("unified_inventory") == nil
 
 local frames_pos = {}
 

--- a/technic/radiation.lua
+++ b/technic/radiation.lua
@@ -344,7 +344,7 @@ local function dmg_abm(pos, node)
 	end
 end
 
-if minetest.setting_getbool("enable_damage") then
+if minetest.settings:get_bool("enable_damage") then
 	minetest.register_abm({
 		label = "Radiation damage",
 		nodenames = {"group:radioactive"},


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267