### PR TITLE
Wrench: Allow picking up with protection_bypass privilege

### DIFF
--- a/wrench/init.lua
+++ b/wrench/init.lua
@@ -120,7 +120,7 @@ minetest.register_tool("wrench:wrench", {
 			return
 		end
 		local meta = minetest.get_meta(pos)
-		if def.owned then
+		if def.owned and not minetest.check_player_privs(placer, "protection_bypass") then
 			local owner = meta:get_string("owner")
 			if owner and owner ~= player_name then
 				minetest.log("action", player_name..


### PR DESCRIPTION
This allows users with protection_bypass to move other players locked chests/etc without hassle (relocating flying chests).  Currently it is not possible, you can move only your own chests.