### PR TITLE
Improve network parsing

### DIFF
--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -190,9 +190,13 @@ local get_network = function(sw_pos, pos1, tier)
 	local all_nodes = {}
 	local queue = {}
 	add_cable_node(all_nodes, pos1, network_id, queue)
-	for _, pos in ipairs(queue) do
-		traverse_network(PR_nodes, RE_nodes, BA_nodes, SP_nodes, all_nodes,
-				pos, technic.machines[tier], tier, sw_pos, network_id, queue)
+	while next(queue) do
+		local to_visit = {}
+		for _, pos in ipairs(queue) do
+			traverse_network(PR_nodes, RE_nodes, BA_nodes, SP_nodes, all_nodes,
+					pos, technic.machines[tier], tier, sw_pos, network_id, to_visit)
+		end
+		queue = to_visit
 	end
 	PR_nodes = flatten(PR_nodes)
 	BA_nodes = flatten(BA_nodes)

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -91,19 +91,22 @@ minetest.register_node("technic:switching_station",{
 --------------------------------------------------
 -- Functions to traverse the electrical network
 --------------------------------------------------
+local function flatten(map)
+	local list = {}
+	for key, value in map do
+		list[#list + 1] = value
+	end
+	return list
+end
 
 -- Add a wire node to the LV/MV/HV network
 local add_new_cable_node = function(nodes, pos, network_id)
-	technic.cables[minetest.hash_node_position(pos)] = network_id
-	-- Ignore if the node has already been added
-	for i = 1, #nodes do
-		if pos.x == nodes[i].x and
-		   pos.y == nodes[i].y and
-		   pos.z == nodes[i].z then
-			return false
-		end
+	local node_id = minetest.hash_node_position(pos)
+	technic.cables[node_id] = network_id
+	if nodes[node_id] then
+		return false
 	end
-	table.insert(nodes, {x=pos.x, y=pos.y, z=pos.z, visited=1})
+	nodes[node_id] = pos
 	return true
 end
 
@@ -188,6 +191,9 @@ local get_network = function(sw_pos, pos1, tier)
 				i, technic.machines[tier], tier, sw_pos, network_id)
 		i = i + 1
 	until all_nodes[i] == nil
+	PR_nodes = flatten(PR_nodes)
+	BA_nodes = flatten(BA_nodes)
+	RE_nodes = flatten(BA_nodes)
 	technic.networks[network_id] = {tier = tier, PR_nodes = PR_nodes, RE_nodes = RE_nodes, BA_nodes = BA_nodes}
 	return PR_nodes, BA_nodes, RE_nodes
 end

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -93,7 +93,7 @@ minetest.register_node("technic:switching_station",{
 --------------------------------------------------
 local function flatten(map)
 	local list = {}
-	for key, value in map do
+	for key, value in pairs(map) do
 		list[#list + 1] = value
 	end
 	return list
@@ -197,7 +197,10 @@ local get_network = function(sw_pos, pos1, tier)
 	PR_nodes = flatten(PR_nodes)
 	BA_nodes = flatten(BA_nodes)
 	RE_nodes = flatten(RE_nodes)
-	technic.networks[network_id] = {tier = tier, PR_nodes = PR_nodes, RE_nodes = RE_nodes, BA_nodes = BA_nodes}
+	SP_nodes = flatten(SP_nodes)
+	all_nodes = flatten(all_nodes)
+	technic.networks[network_id] = {tier = tier, all_nodes = all_nodes, SP_nodes = SP_nodes,
+			PR_nodes = PR_nodes, RE_nodes = RE_nodes, BA_nodes = BA_nodes}
 	return PR_nodes, BA_nodes, RE_nodes
 end
 

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -163,7 +163,8 @@ local touch_nodes = function(list, tier)
 end
 
 local get_network = function(sw_pos, pos1, tier)
-	local cached = technic.networks[minetest.hash_node_position(pos1)]
+	local network_id = minetest.hash_node_position(pos1)
+	local cached = technic.networks[network_id]
 	if cached and cached.tier == tier then
 		touch_nodes(cached.PR_nodes, tier)
 		touch_nodes(cached.BA_nodes, tier)
@@ -180,14 +181,14 @@ local get_network = function(sw_pos, pos1, tier)
 	local BA_nodes = {}
 	local RE_nodes = {}
 	local SP_nodes = {}
-	local all_nodes = {pos1}
+	local all_nodes = {}
+	add_new_cable_node(all_nodes, pos1, network_id)
 	repeat
 		traverse_network(PR_nodes, RE_nodes, BA_nodes, SP_nodes, all_nodes,
-				i, technic.machines[tier], tier, sw_pos, minetest.hash_node_position(pos1))
+				i, technic.machines[tier], tier, sw_pos, network_id)
 		i = i + 1
 	until all_nodes[i] == nil
-	technic.networks[minetest.hash_node_position(pos1)] = {tier = tier, PR_nodes = PR_nodes,
-			RE_nodes = RE_nodes, BA_nodes = BA_nodes, SP_nodes = SP_nodes, all_nodes = all_nodes}
+	technic.networks[network_id] = {tier = tier, PR_nodes = PR_nodes, RE_nodes = RE_nodes, BA_nodes = BA_nodes}
 	return PR_nodes, BA_nodes, RE_nodes
 end
 


### PR DESCRIPTION
Reduces parse time from ~6s to <1s for this construction (16³ nodes):
![screenshot_20180128_020951](https://user-images.githubusercontent.com/7352626/35477289-d5e6f652-03d0-11e8-8e83-9c8e81af3c6b.png)
Internally, it reduces parsing complexity from O(n²) to O(n) (a bit heavier actually, due to reallocations; but still way faster than current one), so for larger networks the effect should be even more noticeable (although mapblock loading may reduce it considerably; depends).
@VanessaE you might be interested in this patch =)