### PR TITLE
Add Support for Ethereal NG plant life

### DIFF
--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -242,8 +242,8 @@ minetest.register_abm({
 
 			local poshash = minetest.hash_node_position(pos)
 
-			if not technic.redundant_warn.poshash then
-				technic.redundant_warn.poshash = true
+			if not technic.redundant_warn[poshash] then
+				technic.redundant_warn[poshash] = true
 				print("[TECHNIC] Warning: redundant switching station found near "..minetest.pos_to_string(pos))
 			end
 			return


### PR DESCRIPTION
Adds in the ability of the chainsaw to cut down plant life generated by the Ethereal mod.
Power level was changed but still needs to be tested out to see whether it will cut down a whole redwood tree and use the whole charge without having any leftover. If it doesn't cut down the whole tree, aesthetically it will not look pleasing to the eye along with leaving nodes hanging out in the open.
Feedback appreciated!