### PR TITLE
Use a:iter instead of for loops for sulfur generation

### DIFF
--- a/technic_worldgen/oregen.lua
+++ b/technic_worldgen/oregen.lua
@@ -141,16 +141,19 @@ minetest.register_on_generated(function(minp, maxp, seed)
 	for y = minp.y + math.floor(grid_size / 2), maxp.y, grid_size do
 	for z = minp.z + math.floor(grid_size / 2), maxp.z, grid_size do
 		local c = data[a:index(x, y, z)]
-		if (c == c_lava or c == c_lava_flowing) and sulfur_noise:get3d({x = x, y = z, z = z}) >= 0.4 then
-			for xx = math.max(minp.x, x - grid_size), math.min(maxp.x, x + grid_size) do
-			for yy = math.max(minp.y, y - grid_size), math.min(maxp.y, y + grid_size) do
-			for zz = math.max(minp.z, z - grid_size), math.min(maxp.z, z + grid_size) do
-				local i = a:index(xx, yy, zz)
+		if (c == c_lava or c == c_lava_flowing)
+		and sulfur_noise:get3d({x = x, y = z, z = z}) >= 0.4 then
+			for i in a:iter(
+				math.max(minp.x, x - grid_size),
+				math.max(minp.y, y - grid_size),
+				math.max(minp.z, z - grid_size),
+				math.min(maxp.x, x + grid_size),
+				math.min(maxp.y, y + grid_size),
+				math.min(maxp.z, z + grid_size)
+			) do
 				if data[i] == c_stone and pr:next(1, 10) <= 7 then
 					data[i] = c_sulfur
 				end
-			end
-			end
 			end
 		end
 	end


### PR DESCRIPTION
The a:iter function is supposed to be used in such situations, it's faster than using for loops with a:index.