### PR TITLE
Show EU power values more readable

### DIFF
--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -11,9 +11,12 @@ switching station handles the network activity.
 
 Helper functions
 ----------------
+* `technic.EU_string(num)`
+	* Converts num to a human-readable string with unit
+	* Use this function when showing players power values
 * `technic.pretty_num(num)`
-	* Converts the number `num` to a human-readable string.
-	* Use this function when showing players power values.
+	* Converts the number `num` to a human-readable string
+	* This function is currently unused by technic (legacy).
 * `technic.swap_node(pos, nodename)`
 	* Same as `mintest.swap_node` but it only changes the nodename.
 	* It uses `minetest.get_node` before swapping to ensure the new nodename

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -21,6 +21,32 @@ function technic.pretty_num(num)
 end
 
 
+local prefixes = {[-24] = "y", [-21] = "z", [-18] = "a", [-15] = "f",
+	[-12] = "p", [-9] = "n", [-6] = "µ", [0] = "", [-3] = "m", [3] = "k", [6] = "M",
+	[9] = "G", [12] = "T", [15] = "P", [18] = "E", [21] = "Z", [24] = "Y"}
+local digits = 4  -- shouldn't be less than 4
+function technic.EU_string(num)
+	if num == 0
+	or num * 0 ~= num * 0 then
+		-- ±0, ±inf or ±nan
+		return tostring(num)
+	end
+	local b = math.floor(math.log(num) / math.log(10) +0.000001)
+	b3 = math.floor((b - math.sign(b)) / 3) * 3
+	if math.abs(b) < digits-1 then
+		b = 0
+	else
+		b = b - (digits-1) * math.sign(b)
+	end
+	if not prefixes[b3] then
+		-- not likely going to happend
+		return tostring(num) .. " EU"
+	end
+	num = math.floor(num / 10^b +.5) * 10^(b - b3)
+	return num .. " " .. prefixes[b3] .. "EU"
+end
+
+
 --- Same as minetest.swap_node, but only changes name
 -- and doesn't re-set if already set.
 function technic.swap_node(pos, name)

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -40,10 +40,10 @@ function technic.EU_string(num)
 	end
 	if not prefixes[b3] then
 		-- not likely going to happend
-		return tostring(num) .. " EU"
+		return tostring(num) .. " EU"
 	end
 	num = math.floor(num / 10^b +.5) * 10^(b - b3)
-	return num .. " " .. prefixes[b3] .. "EU"
+	return num .. " " .. prefixes[b3] .. "EU"
 end
 
 

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -26,9 +26,8 @@ local prefixes = {[-24] = "y", [-21] = "z", [-18] = "a", [-15] = "f",
 	[9] = "G", [12] = "T", [15] = "P", [18] = "E", [21] = "Z", [24] = "Y"}
 local digits = 4  -- shouldn't be less than 4
 function technic.EU_string(num)
-	if num == 0
-	or num * 0 ~= num * 0 then
-		-- ±0, ±inf or ±nan
+	if num * 0 ~= num * 0 then
+		-- ±inf or ±nan
 		return tostring(num)
 	end
 	local b = math.floor(math.log(num) / math.log(10) +0.000001)

--- a/technic/machines/LV/solar_panel.lua
+++ b/technic/machines/LV/solar_panel.lua
@@ -35,7 +35,8 @@ local run = function(pos, node)
 		local charge_to_give = math.floor((light + pos1.y) * 3)
 		charge_to_give = math.max(charge_to_give, 0)
 		charge_to_give = math.min(charge_to_give, 200)
-		meta:set_string("infotext", S("@1 Active (@2 EU)", machine_name, technic.pretty_num(charge_to_give)))
+		meta:set_string("infotext", S("@1 Active (@2)", machine_name,
+			technic.EU_string(charge_to_give)))
 		meta:set_int("LV_EU_supply", charge_to_give)
 	else
 		meta:set_string("infotext", S("%s Idle"):format(machine_name))
@@ -54,7 +55,7 @@ minetest.register_node("technic:solar_panel", {
 	active = false,
 	drawtype = "nodebox",
 	paramtype = "light",
-	is_ground_content = true,	
+	is_ground_content = true,
 	node_box = {
 		type = "fixed",
 		fixed = {-0.5, -0.5, -0.5, 0.5, 0, 0.5},

--- a/technic/machines/MV/wind_mill.lua
+++ b/technic/machines/MV/wind_mill.lua
@@ -60,7 +60,8 @@ local run = function(pos, node)
 	elseif check == true then
 		local power = math.min(pos.y * 100, 5000)
 		meta:set_int("MV_EU_supply", power)
-		meta:set_string("infotext", S("@1 (@2 EU)", machine_name, technic.pretty_num(power)))
+		meta:set_string("infotext", S("@1 (@2)", machine_name,
+			technic.EU_string(power)))
 	end
 	-- check == nil: assume nothing has changed
 end

--- a/technic/machines/power_monitor.lua
+++ b/technic/machines/power_monitor.lua
@@ -55,7 +55,7 @@ minetest.register_abm({
 			local demand = sw_meta:get_int("demand")
 			meta:set_string("infotext",
 					S("Power Monitor. Supply: @1 Demand: @2",
-					technic.pretty_num(supply), technic.pretty_num(demand)))
+					technic.EU_string(supply), technic.EU_string(demand)))
 		else
 			meta:set_string("infotext",S("Power Monitor Has No Network"))
 		end

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -255,8 +255,9 @@ function technic.register_battery_box(data)
 
 		local charge_percent = math.floor(current_charge / max_charge * 100)
 		meta:set_string("formspec", formspec..add_on_off_buttons(meta, ltier, charge_percent))
-		local infotext = S("@1 Battery Box: @2/@3", tier,
-				technic.pretty_num(current_charge), technic.pretty_num(max_charge))
+		local infotext = S("@1 Battery Box: @2 / @3", tier,
+				technic.EU_string(current_charge),
+				technic.EU_string(max_charge))
 		if eu_input == 0 then
 			infotext = S("%s Idle"):format(infotext)
 		end

--- a/technic/machines/register/solar_array.lua
+++ b/technic/machines/register/solar_array.lua
@@ -30,14 +30,15 @@ function technic.register_solar_array(data)
 			local charge_to_give = math.floor((light + pos.y) * data.power)
 			charge_to_give = math.max(charge_to_give, 0)
 			charge_to_give = math.min(charge_to_give, data.power * 50)
-			meta:set_string("infotext", S("@1 Active (@2 EU)", machine_name, technic.pretty_num(charge_to_give)))
+			meta:set_string("infotext", S("@1 Active (@2)", machine_name,
+				technic.EU_string(charge_to_give)))
 			meta:set_int(tier.."_EU_supply", charge_to_give)
 		else
 			meta:set_string("infotext", S("%s Idle"):format(machine_name))
 			meta:set_int(tier.."_EU_supply", 0)
 		end
 	end
-	
+
 	minetest.register_node("technic:solar_array_"..ltier, {
 		tiles = {"technic_"..ltier.."_solar_array_top.png",  "technic_"..ltier.."_solar_array_bottom.png",
 			 "technic_"..ltier.."_solar_array_side.png", "technic_"..ltier.."_solar_array_side.png",

--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -149,7 +149,9 @@ local run = function(pos, node, run_stage)
 		meta:set_int(from.."_EU_supply", 0)
 		meta:set_int(to.."_EU_demand", 0)
 		meta:set_int(to.."_EU_supply", input * remain)
-		meta:set_string("infotext", S("@1 (@2 @3 -> @4 @5)", machine_name, technic.pretty_num(input), from, technic.pretty_num(input * remain), to))
+		meta:set_string("infotext", S("@1 (@2 @3 -> @4 @5)", machine_name,
+			technic.EU_string(input), from,
+			technic.EU_string(input * remain), to))
 	else
 		meta:set_string("infotext", S("%s Has Bad Cabling"):format(machine_name))
 		if to then

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -361,9 +361,9 @@ minetest.register_abm({
 		end
 		--dprint("Total BA demand:"..BA_eu_demand)
 
-		meta:set_string("infotext",
-				S("@1. Supply: @2 Demand: @3",
-				machine_name, technic.pretty_num(PR_eu_supply), technic.pretty_num(RE_eu_demand)))
+		meta:set_string("infotext", S("@1. Supply: @2 Demand: @3",
+				machine_name, technic.EU_string(PR_eu_supply),
+				technic.EU_string(RE_eu_demand)))
 
 		-- If mesecon signal and power supply or demand changed then
 		-- send them via digilines.

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -361,7 +361,7 @@ minetest.register_abm({
 		end
 		--dprint("Total BA demand:"..BA_eu_demand)
 
-		meta:set_string("infotext", S("@1. Supply: @2 Demand: @3",
+		meta:set_string("infotext", S("@1. Supply: @2 Demand: @3",
 				machine_name, technic.EU_string(PR_eu_supply),
 				technic.EU_string(RE_eu_demand)))
 


### PR DESCRIPTION
Add the EU_string helper function
In comparison to pretty_num it uses SI prefixes, adds "EU" (e.g. kEU) and rounds the number for readability

Before:
![old](https://user-images.githubusercontent.com/3192173/39968789-0bde762c-56d3-11e8-8c78-d5bc5397d79d.jpg)

After:
![new](https://user-images.githubusercontent.com/3192173/39968792-10ef4d76-56d3-11e8-9778-e70955edbd6a.jpg)
(of course, the BB collected some power between taking the screenshots)

I've noticed that infotext is sometimes line-broken in minetest, which would puts the EU unit into the next line. Therefore I've changed the space to a non-breaking space character: ` `, are you fine with this?
