### PR TITLE
Add "creative mode" option

### DIFF
--- a/technic/config.lua
+++ b/technic/config.lua
@@ -14,6 +14,7 @@ local defaults = {
 	enable_longterm_radiation_damage = "true",
 	enable_nuclear_reactor_digiline_selfdestruct = "false",
 	creative_mode = "false",
+	enable_producers = "true",
 }
 
 for k, v in pairs(defaults) do

--- a/technic/config.lua
+++ b/technic/config.lua
@@ -13,6 +13,7 @@ local defaults = {
 	enable_entity_radiation_damage = "true",
 	enable_longterm_radiation_damage = "true",
 	enable_nuclear_reactor_digiline_selfdestruct = "false",
+	creative_mode = "false",
 }
 
 for k, v in pairs(defaults) do

--- a/technic/machines/HV/init.lua
+++ b/technic/machines/HV/init.lua
@@ -8,9 +8,11 @@ dofile(path.."/cables.lua")
 dofile(path.."/battery_box.lua")
 
 -- Generators
-dofile(path.."/solar_array.lua")
-dofile(path.."/nuclear_reactor.lua")
-dofile(path.."/generator.lua")
+if technic.config:get_bool("enable_producers") then
+	dofile(path.."/solar_array.lua")
+	dofile(path.."/nuclear_reactor.lua")
+	dofile(path.."/generator.lua")
+end
 
 -- Machines
 dofile(path.."/quarry.lua")

--- a/technic/machines/LV/init.lua
+++ b/technic/machines/LV/init.lua
@@ -8,11 +8,13 @@ dofile(path.."/cables.lua")
 dofile(path.."/battery_box.lua")
 
 -- Generators
-dofile(path.."/solar_panel.lua")
-dofile(path.."/solar_array.lua")
-dofile(path.."/geothermal.lua")
-dofile(path.."/water_mill.lua")
-dofile(path.."/generator.lua")
+if technic.config:get_bool("enable_producers") then
+	dofile(path.."/solar_panel.lua")
+	dofile(path.."/solar_array.lua")
+	dofile(path.."/geothermal.lua")
+	dofile(path.."/water_mill.lua")
+	dofile(path.."/generator.lua")
+end
 
 -- Machines
 dofile(path.."/alloy_furnace.lua")

--- a/technic/machines/MV/init.lua
+++ b/technic/machines/MV/init.lua
@@ -8,11 +8,13 @@ dofile(path.."/cables.lua")
 dofile(path.."/battery_box.lua")
 
 -- Generators
-if technic.config:get_bool("enable_wind_mill") then
-	dofile(path.."/wind_mill.lua")
+if technic.config:get_bool("enable_producers") then
+	if technic.config:get_bool("enable_wind_mill") then
+		dofile(path.."/wind_mill.lua")
+	end
+	dofile(path.."/generator.lua")
+	dofile(path.."/solar_array.lua")
 end
-dofile(path.."/generator.lua")
-dofile(path.."/solar_array.lua")
 
 -- Machines
 dofile(path.."/alloy_furnace.lua")

--- a/technic/machines/creative.lua
+++ b/technic/machines/creative.lua
@@ -1,0 +1,41 @@
+local S = technic.getter
+
+minetest.register_abm({
+	nodenames = {"group:technic_lv", "group:technic_mv", "group:technic_hv"},
+	label = "Run Machines",
+	interval   = 1,
+	chance     = 1,
+	action = function(pos,node)
+		local meta = minetest.get_meta(pos)
+		local pos1 = {x=pos.x, y=pos.y-1, z=pos.z}
+		local tier = technic.get_cable_tier(minetest.get_node(pos1).name)
+		local meta = minetest.get_meta(pos)
+		if not tier then
+			meta:set_int("active", 0)
+			return
+		end
+		meta:set_int("active", 1)
+		meta:set_int("LV_EU_input", meta:get_int("LV_EU_demand"))
+		meta:set_int("MV_EU_input", meta:get_int("MV_EU_demand"))
+		meta:set_int("HV_EU_input", meta:get_int("HV_EU_demand"))
+		local nodedef = minetest.registered_nodes[node.name]
+		if nodedef and nodedef.technic_run then
+			nodedef.technic_run(pos, node)
+		end
+	end,
+})
+
+minetest.register_lbm({
+	nodenames = {"technic:switching_station", "technic:power_monitor"},
+	name = "technic:update_infotext",
+	label = "Update switching station / power monitor infotext",
+	run_at_every_load = true,
+	action = function(pos, node)
+		local meta = minetest.get_meta(pos)
+		if node.name == "technic:switching_station" then
+			meta:set_string("infotext", S("Switching Station"))
+		elseif node.name == "technic:power_monitor" then
+			meta:set_string("infotext", S("Power Monitor"))
+		end
+	end,
+})

--- a/technic/machines/init.lua
+++ b/technic/machines/init.lua
@@ -13,3 +13,8 @@ dofile(path.."/supply_converter.lua")
 
 dofile(path.."/other/init.lua")
 
+if technic.config:get_bool("creative_mode") then
+	--The switching station does not handle running machines
+	--in this mode, so alternative means are used to do so.
+	dofile(path.."/creative.lua")
+end

--- a/technic/machines/power_monitor.lua
+++ b/technic/machines/power_monitor.lua
@@ -35,6 +35,12 @@ minetest.register_node("technic:power_monitor",{
 	end,
 })
 
+if technic.config:get_bool("creative_mode") then
+	--Power distribution is not used in this mode,
+	--so the power monitor is inert and never needs to run.
+	return
+end
+
 minetest.register_abm({
 	nodenames = {"technic:power_monitor"},
 	label = "Machines: run power monitor",

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -88,6 +88,13 @@ minetest.register_node("technic:switching_station",{
 	},
 })
 
+if technic.config:get_bool("creative_mode") then
+	--Power distribution is not used in this mode,
+	--so the switching station is inert and none of the
+	--network processing is needed.
+	return
+end
+
 --------------------------------------------------
 -- Functions to traverse the electrical network
 --------------------------------------------------


### PR DESCRIPTION
This does not change the default behavior, but if "creative_mode" is set to true in technic.conf, this completely disables power distribution and causes the following to happen, regardless of whether there is a switching station connected:
* Switching Stations and Power Monitors become inert
* Generators placed on top of a suitable cable will run (consume fuel if applicable, update infotext, and so on)
* Batteries placed on top of a suitable cable will charge at maximum speed and remain fully charged
* Machines that consume energy and are placed on top of a suitable cable will run normally, regardless of whether any power is present
* Power distribution logic will not run and networks will not be calculated

This also includes an "enable_producers" option, added at the request of a server owner (I'd be open to a better name for this one). The default is true, but if set to false it skips registering all generator/producer nodes. It is intended for use in conjunction with creative mode but will work, albeit somewhat pointlessly, regardless.