### PR TITLE
Fix connect_sides of active fuel-fired generators

### DIFF
--- a/technic/machines/register/generator.lua
+++ b/technic/machines/register/generator.lua
@@ -191,7 +191,7 @@ function technic.register_generator(data)
 		},
 		paramtype2 = "facedir",
 		groups = active_groups,
-		connect_sides = {"bottom"},
+		connect_sides = {"bottom", "back", "left", "right"},
 		legacy_facedir_simple = true,
 		sounds = default.node_sound_wood_defaults(),
 		tube = data.tube and tube or nil,


### PR DESCRIPTION
Fuel-fired generators can output power on the bottom, back, left, and right.
Inactive generators had connect_sides correctly set to {"bottom", "back", "left", "right"}, but *active* generators only had {"bottom"} for some reason.
This caused generators to appear to disconnect from cables after being turned on.