### PR TITLE
fixes #441

### DIFF
--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -146,15 +146,9 @@ local function quarry_run(pos, node)
 				dignode = technic.get_or_load_node(digpos) or minetest.get_node(digpos)
 				local dignodedef = minetest.registered_nodes[dignode.name] or {diggable=false}
 				-- doors mod among other thing does NOT like a nil digger...
-				local fakedigger = {
-					get_player_name = function()
-						return "!technic_quarry_fake_digger"
-					end,
-					is_player = function() return false end,
-					get_wielded_item = function()
-						return ItemStack("air")
-					end,
-				}
+				local fakedigger = pipeworks.create_fake_player({
+					name = owner
+				})
 				if not dignodedef.diggable or (dignodedef.can_dig and not dignodedef.can_dig(digpos, fakedigger)) then
 					can_dig = false
 				end


### PR DESCRIPTION
Quarry uses a fake-digger created by pipeworks (hard-dependency)
Fixes crash when digging empty protected chests (https://github.com/minetest/minetest_game/blob/backport-0.4/mods/default/nodes.lua#L1868)