### PR TITLE
Check protection of the forcefield and Quarry

### DIFF
--- a/technic/machines/HV/forcefield.lua
+++ b/technic/machines/HV/forcefield.lua
@@ -126,6 +126,12 @@ local function set_forcefield_formspec(meta)
 end
 
 local forcefield_receive_fields = function(pos, formname, fields, sender)
+	local player_name = sender:get_player_name()
+	if minetest.is_protected(pos, player_name) then
+		minetest.chat_send_player(player_name, "You are not allowed to edit this!")
+		minetest.record_protection_violation(pos, player_name)
+		return
+	end
 	local meta = minetest.get_meta(pos)
 	local range = nil
 	if fields.range then

--- a/technic/machines/HV/quarry.lua
+++ b/technic/machines/HV/quarry.lua
@@ -60,6 +60,12 @@ local function set_quarry_demand(meta)
 end
 
 local function quarry_receive_fields(pos, formname, fields, sender)
+	local player_name = sender:get_player_name()
+	if minetest.is_protected(pos, player_name) then
+		minetest.chat_send_player(player_name, "You are not allowed to edit this!")
+		minetest.record_protection_violation(pos, player_name)
+		return
+	end
 	local meta = minetest.get_meta(pos)
 	if fields.size and string.find(fields.size, "^[0-9]+$") then
 		local size = tonumber(fields.size)


### PR DESCRIPTION
With change the range or form of the force-field are very bad things possible.
For example in my case someone changed the range and my two reactors melted down because the water got removed.
This PR adds just a check if the force-field is protected.

Same for quarry