### PR TITLE
Inverse recipe to Freezer

### DIFF
--- a/technic/machines/register/alloy_recipes.lua
+++ b/technic/machines/register/alloy_recipes.lua
@@ -28,6 +28,7 @@ local recipes = {
 	-- The highest volume use of carbon black is as a reinforcing filler in rubber products, especially tires.
 	-- "[Compounding a] pure gum vulcanizate … with 50% of its weight of carbon black improves its tensile strength and wear resistance …" 
 	{"technic:raw_latex 4",           "technic:coal_dust 2",        "technic:rubber 6", 2},
+	{"default:ice", 		  "bucket:bucket_empty",        "bucket:bucket_water", 1 },
 }
 
 for _, data in pairs(recipes) do


### PR DESCRIPTION
I think that adding that new MV Freezer machine to the master branch was a failure, it was not good idea. This machine does not do anything useful and has no usage in technology tree. And what's worse, it's very annoying that it (1) does not have reverse process and (2) it completely ignore the canisters! Who to hell use buckets when playing technic? There are water cans! This machine should use water cans to make ice exactly the same as it uses water buckets. But making the code for that can be hard. It is much easier to fix the first problem.

So, MV Freezer gives the recipe: water bucket -> ice + empty bucket. Let`s enable making water from ice. (Although technic has powerful furnaces for melting metals, these furnaces can`t melt ice!) Perhaps it seems more obvious that the ice should be melted directly into water source in furnaces. But MV Freezer uses buckets, so I also suggest using buckets in ice-to-water making. There is only one machine that allow two inputs: alloy furnace. So that is the idea: ice + empty bucket -> water bucket.  If you have an objection against the use of alloy furnaces here, notice that it is awkward to carry water directly by your hands. I think this also chould use cans, so this is not perfect either... :/