### PR TITLE
Reject constructor in constructor slot inventories

### DIFF
--- a/technic/machines/other/constructor.lua
+++ b/technic/machines/other/constructor.lua
@@ -118,6 +118,12 @@ local function make_off(mark)
 	end
 end
 
+local function allow_inventory_put(pos, listname, index, stack, player)
+	if stack and minetest.get_item_group(stack:get_name(), "technic_constructor") == 1 then
+		return 0
+	end
+	return technic.machine_inventory_put(pos, listname, index, stack, player)
+end
 
 local function make_constructor(mark, length)
 	minetest.register_node("technic:constructor_mk"..mark.."_off", {
@@ -129,7 +135,8 @@ local function make_constructor(mark, length)
 			"technic_constructor_back.png",
 			"technic_constructor_front_off.png"},
 		paramtype2 = "facedir",
-		groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2, mesecon = 2},
+		groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2,
+			mesecon = 2, technic_constructor = 1},
 		mesecons = {effector = {action_on = make_on(mark, length)}},
 		sounds = default.node_sound_stone_defaults(),
 		on_construct = function(pos)
@@ -160,7 +167,7 @@ local function make_constructor(mark, length)
 			end
 			return true
 		end,
-		allow_metadata_inventory_put = technic.machine_inventory_put,
+		allow_metadata_inventory_put = allow_inventory_put,
 		allow_metadata_inventory_take = technic.machine_inventory_take,
 		allow_metadata_inventory_move = technic.machine_inventory_move,
 		on_rotate = screwdriver.rotate_simple
@@ -176,10 +183,10 @@ local function make_constructor(mark, length)
 		paramtype2 = "facedir",
 		drop = "technic:constructor_mk"..mark.."_off",
 		groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2,
-			mesecon=2, not_in_creative_inventory=1},
+			mesecon=2, not_in_creative_inventory=1, technic_constructor=1},
 		mesecons= {effector = {action_off = make_off(mark)}},
 		sounds = default.node_sound_stone_defaults(),
-		allow_metadata_inventory_put = technic.machine_inventory_put,
+		allow_metadata_inventory_put = allow_inventory_put,
 		allow_metadata_inventory_take = technic.machine_inventory_take,
 		allow_metadata_inventory_move = technic.machine_inventory_move,
 		on_rotate = false


### PR DESCRIPTION
This prevents using cascading constructors to get past protection, fixing #503.