### PR TITLE
Fix radiation protection when armor group is not set

### DIFF
--- a/technic/radiation.lua
+++ b/technic/radiation.lua
@@ -294,6 +294,8 @@ local function calculate_damage_multiplier(object)
 	end
 	if ag.radiation then
 		return 0.01 * ag.radiation
+	elseif armor_enabled then
+		return 0
 	end
 	if ag.fleshy then
 		return math.sqrt(0.01 * ag.fleshy)


### PR DESCRIPTION
The radiation damage group can be not set when armor completely protects against radiation or when no mod has set a default value for the damage group. We want to apply radiation damage in the second case but not in the first. Previously this worked because the damage group was set to 0 in the first case, but this was changed by minetest/minetest#8751 and `calculate_damage_multiplier` wrongly treated differently the damage group value being 0 and not set.