### PR TITLE
technic_cnc/cnc.lua: fix access to non-existant stack parameter

### DIFF
--- a/technic_cnc/cnc.lua
+++ b/technic_cnc/cnc.lua
@@ -59,7 +59,7 @@ else
 		if minetest.is_protected(pos, player:get_player_name()) then
 			return 0
 		end
-		return stack:get_count()
+		return count
 	end
 
 	can_dig = function(pos, player)


### PR DESCRIPTION
This implementation of allow_metadata_inventory_move appears to have been written like the other allow_* functions in this file, but for this particular function stack is not actually a parameter passed, only the actual count.
Return that instead of trying to reference a non-existant variable and crashing.