### PR TITLE
Fix crash when placing cable plates

### DIFF
--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -215,7 +215,7 @@ function technic.register_cable(tier, size)
 		if i == 1 then
 			def.on_place = function(itemstack, placer, pointed_thing)
 				local pointed_thing_diff = vector.subtract(pointed_thing.above, pointed_thing.under)
-				local num
+				local num = 1
 				local changed
 				for k, v in pairs(pointed_thing_diff) do
 					if v ~= 0 then
@@ -225,7 +225,7 @@ function technic.register_cable(tier, size)
 					end
 				end
 				local crtl = placer:get_player_control()
-				if (crtl.aux1 or crtl.sneak) and not (crtl.aux1 and crtl.sneak) then
+				if (crtl.aux1 or crtl.sneak) and not (crtl.aux1 and crtl.sneak) and changed then
 					local fine_pointed = minetest.pointed_thing_to_face_pos(placer, pointed_thing)
 					fine_pointed = vector.subtract(fine_pointed, pointed_thing.above)
 					fine_pointed[changed] = nil


### PR DESCRIPTION
All coordinates can be equal if pointed_thing.above is identical to pointed_thing.under. This [happens](https://github.com/SwissalpS/replacer/blob/608c8c42ac3154f3b9393a85773eb01361cdd101/replacer.lua#L190) when placing a cable plate with replacer.