### PR TITLE
Protector redo mod support for technic chests

### DIFF
--- a/technic_chests/common.lua
+++ b/technic_chests/common.lua
@@ -36,6 +36,15 @@ local function inv_change(pos, count, player)
 	return count
 end
 
+local function inv_change_protected(pos, count, player)
+	-- Skip check for pipeworks (fake player)
+	if minetest.is_player(player) and
+			minetest.is_protected(pos, player:get_player_name()) then
+		return 0
+	end
+	return count
+end
+
 function technic.chests.inv_move(pos, from_list, from_index, to_list, to_index, count, player)
 	return inv_change(pos, count, player)
 end
@@ -44,6 +53,16 @@ function technic.chests.inv_put(pos, listname, index, stack, player)
 end
 function technic.chests.inv_take(pos, listname, index, stack, player)
 	return inv_change(pos, stack:get_count(), player)
+end
+
+function technic.chests.inv_move_protected(pos, from_list, from_index, to_list, to_index, count, player)
+	return inv_change_protected(pos, count, player)
+end
+function technic.chests.inv_put_protected(pos, listname, index, stack, player)
+	return inv_change_protected(pos, stack:get_count(), player)
+end
+function technic.chests.inv_take_protected(pos, listname, index, stack, player)
+	return inv_change_protected(pos, stack:get_count(), player)
 end
 
 function technic.chests.on_inv_move(pos, from_list, from_index, to_list, to_index, count, player)

--- a/technic_chests/copper_chest.lua
+++ b/technic_chests/copper_chest.lua
@@ -17,11 +17,11 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'technic:copper_locked_chest 1',
-	recipe = {
-		{'basic_materials:padlock'},
-		{'technic:copper_chest'},
-	}
+    output = 'technic:copper_locked_chest 1',
+    recipe = {
+        {'basic_materials:padlock'},
+        {'technic:copper_chest'},
+    }
 })
 
 technic.chests:register("Copper", {
@@ -32,6 +32,7 @@ technic.chests:register("Copper", {
 	infotext = false,
 	color = false,
 	locked = false,
+    protected = false,
 })
 
 technic.chests:register("Copper", {
@@ -42,5 +43,35 @@ technic.chests:register("Copper", {
 	infotext = false,
 	color = false,
 	locked = true,
+    protected = false,
 })
 
+if minetest.get_modpath("protector") then
+    minetest.register_craft({
+        output = 'technic:copper_protected_chest 1',
+        recipe = {
+            {'default:copper_ingot','default:copper_ingot','default:copper_ingot'},
+            {'default:copper_ingot','technic:iron_protected_chest','default:copper_ingot'},
+            {'default:copper_ingot','default:copper_ingot','default:copper_ingot'},
+        }
+    })
+
+    minetest.register_craft({
+        output = 'technic:copper_protected_chest 1',
+        recipe = {
+            {'default:copper_ingot'},
+            {'technic:copper_chest'},
+        }
+    })
+
+    technic.chests:register("Copper", {
+        width = 12,
+        height = 5,
+        sort = true,
+        autosort = true,
+        infotext = false,
+        color = false,
+        locked = false,
+        protected = true,
+    })
+end

--- a/technic_chests/copper_chest.lua
+++ b/technic_chests/copper_chest.lua
@@ -17,11 +17,11 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-    output = 'technic:copper_locked_chest 1',
-    recipe = {
-        {'basic_materials:padlock'},
-        {'technic:copper_chest'},
-    }
+	output = 'technic:copper_locked_chest 1',
+	recipe = {
+		{'basic_materials:padlock'},
+		{'technic:copper_chest'},
+	}
 })
 
 technic.chests:register("Copper", {
@@ -32,7 +32,7 @@ technic.chests:register("Copper", {
 	infotext = false,
 	color = false,
 	locked = false,
-    protected = false,
+	protected = false,
 })
 
 technic.chests:register("Copper", {
@@ -43,35 +43,35 @@ technic.chests:register("Copper", {
 	infotext = false,
 	color = false,
 	locked = true,
-    protected = false,
+	protected = false,
 })
 
 if minetest.get_modpath("protector") then
-    minetest.register_craft({
-        output = 'technic:copper_protected_chest 1',
-        recipe = {
-            {'default:copper_ingot','default:copper_ingot','default:copper_ingot'},
-            {'default:copper_ingot','technic:iron_protected_chest','default:copper_ingot'},
-            {'default:copper_ingot','default:copper_ingot','default:copper_ingot'},
-        }
-    })
+	minetest.register_craft({
+		output = 'technic:copper_protected_chest 1',
+		recipe = {
+			{'default:copper_ingot','default:copper_ingot','default:copper_ingot'},
+			{'default:copper_ingot','technic:iron_protected_chest','default:copper_ingot'},
+			{'default:copper_ingot','default:copper_ingot','default:copper_ingot'},
+		}
+	})
 
-    minetest.register_craft({
-        output = 'technic:copper_protected_chest 1',
-        recipe = {
-            {'default:copper_ingot'},
-            {'technic:copper_chest'},
-        }
-    })
+	minetest.register_craft({
+		output = 'technic:copper_protected_chest 1',
+		recipe = {
+			{'default:copper_ingot'},
+			{'technic:copper_chest'},
+		}
+	})
 
-    technic.chests:register("Copper", {
-        width = 12,
-        height = 5,
-        sort = true,
-        autosort = true,
-        infotext = false,
-        color = false,
-        locked = false,
-        protected = true,
-    })
+	technic.chests:register("Copper", {
+		width = 12,
+		height = 5,
+		sort = true,
+		autosort = true,
+		infotext = false,
+		color = false,
+		locked = false,
+		protected = true,
+	})
 end

--- a/technic_chests/depends.txt
+++ b/technic_chests/depends.txt
@@ -5,3 +5,4 @@ moreores?
 pipeworks?
 intllib?
 tubelib?
+protector?

--- a/technic_chests/gold_chest.lua
+++ b/technic_chests/gold_chest.lua
@@ -26,16 +26,16 @@ for _, material in ipairs(material_list) do
 		}
 	})
 
-    if minetest.get_modpath("protector") then
-        minetest.register_craft({
-            output = 'technic:gold_protected_chest',
-            recipe = {
-                {'default:gold_ingot','default:gold_ingot','default:gold_ingot'},
-                {'default:gold_ingot',"technic:"..material.."_protected_chest",'default:gold_ingot'},
-                {'default:gold_ingot','default:gold_ingot','default:gold_ingot'},
-            }
-        })
-    end
+	if minetest.get_modpath("protector") then
+		minetest.register_craft({
+			output = 'technic:gold_protected_chest',
+			recipe = {
+				{'default:gold_ingot','default:gold_ingot','default:gold_ingot'},
+				{'default:gold_ingot',"technic:"..material.."_protected_chest",'default:gold_ingot'},
+				{'default:gold_ingot','default:gold_ingot','default:gold_ingot'},
+			}
+		})
+	end
 end
 
 minetest.register_craft({
@@ -54,7 +54,7 @@ technic.chests:register("Gold", {
 	infotext = true,
 	color = true,
 	locked = false,
-    protected = false,
+	protected = false,
 })
 
 technic.chests:register("Gold", {
@@ -65,26 +65,26 @@ technic.chests:register("Gold", {
 	infotext = true,
 	color = true,
 	locked = true,
-    protected = false,
+	protected = false,
 })
 
 if minetest.get_modpath("protector") then
-    minetest.register_craft({
-        output = 'technic:gold_protected_chest',
-        recipe = {
-            {'default:copper_ingot'},
-            {'technic:gold_chest'},
-        }
-    })
+	minetest.register_craft({
+		output = 'technic:gold_protected_chest',
+		recipe = {
+			{'default:copper_ingot'},
+			{'technic:gold_chest'},
+		}
+	})
 
-    technic.chests:register("Gold", {
-        width = 15,
-        height = 6,
-        sort = true,
-        autosort = true,
-        infotext = true,
-        color = true,
-        locked = false,
-        protected = true,
-    })
+	technic.chests:register("Gold", {
+		width = 15,
+		height = 6,
+		sort = true,
+		autosort = true,
+		infotext = true,
+		color = true,
+		locked = false,
+		protected = true,
+	})
 end

--- a/technic_chests/gold_chest.lua
+++ b/technic_chests/gold_chest.lua
@@ -25,6 +25,17 @@ for _, material in ipairs(material_list) do
 			{'default:gold_ingot','default:gold_ingot','default:gold_ingot'},
 		}
 	})
+
+    if minetest.get_modpath("protector") then
+        minetest.register_craft({
+            output = 'technic:gold_protected_chest',
+            recipe = {
+                {'default:gold_ingot','default:gold_ingot','default:gold_ingot'},
+                {'default:gold_ingot',"technic:"..material.."_protected_chest",'default:gold_ingot'},
+                {'default:gold_ingot','default:gold_ingot','default:gold_ingot'},
+            }
+        })
+    end
 end
 
 minetest.register_craft({
@@ -43,6 +54,7 @@ technic.chests:register("Gold", {
 	infotext = true,
 	color = true,
 	locked = false,
+    protected = false,
 })
 
 technic.chests:register("Gold", {
@@ -53,5 +65,26 @@ technic.chests:register("Gold", {
 	infotext = true,
 	color = true,
 	locked = true,
+    protected = false,
 })
 
+if minetest.get_modpath("protector") then
+    minetest.register_craft({
+        output = 'technic:gold_protected_chest',
+        recipe = {
+            {'default:copper_ingot'},
+            {'technic:gold_chest'},
+        }
+    })
+
+    technic.chests:register("Gold", {
+        width = 15,
+        height = 6,
+        sort = true,
+        autosort = true,
+        infotext = true,
+        color = true,
+        locked = false,
+        protected = true,
+    })
+end

--- a/technic_chests/iron_chest.lua
+++ b/technic_chests/iron_chest.lua
@@ -39,7 +39,7 @@ technic.chests:register("Iron", {
 	infotext = false,
 	color = false,
 	locked = false,
-    protected = false,
+	protected = false,
 })
 
 technic.chests:register("Iron", {
@@ -50,35 +50,35 @@ technic.chests:register("Iron", {
 	infotext = false,
 	color = false,
 	locked = true,
-    protected = false,
+	protected = false,
 })
 
 if minetest.get_modpath("protector") then
-    minetest.register_craft({
-        output = 'technic:iron_protected_chest 1',
-        recipe = {
-            {cast_iron_ingot,cast_iron_ingot,cast_iron_ingot},
-            {cast_iron_ingot,'protector:chest',cast_iron_ingot},
-            {cast_iron_ingot,cast_iron_ingot,cast_iron_ingot},
-        }
-    })
+	minetest.register_craft({
+		output = 'technic:iron_protected_chest 1',
+		recipe = {
+			{cast_iron_ingot,cast_iron_ingot,cast_iron_ingot},
+			{cast_iron_ingot,'protector:chest',cast_iron_ingot},
+			{cast_iron_ingot,cast_iron_ingot,cast_iron_ingot},
+		}
+	})
 
-    minetest.register_craft({
-        output = 'technic:iron_protected_chest 1',
-        recipe = {
-            {'default:copper_ingot'},
-            {'technic:iron_chest'},
-        }
-    })
+	minetest.register_craft({
+		output = 'technic:iron_protected_chest 1',
+		recipe = {
+			{'default:copper_ingot'},
+			{'technic:iron_chest'},
+		}
+	})
 
-    technic.chests:register("Iron", {
-        width = 9,
-        height = 5,
-        sort = true,
-        autosort = false,
-        infotext = false,
-        color = false,
-        locked = false,
-        protected = true,
-    })
+	technic.chests:register("Iron", {
+		width = 9,
+		height = 5,
+		sort = true,
+		autosort = false,
+		infotext = false,
+		color = false,
+		locked = false,
+		protected = true,
+	})
 end

--- a/technic_chests/iron_chest.lua
+++ b/technic_chests/iron_chest.lua
@@ -39,6 +39,7 @@ technic.chests:register("Iron", {
 	infotext = false,
 	color = false,
 	locked = false,
+    protected = false,
 })
 
 technic.chests:register("Iron", {
@@ -49,5 +50,35 @@ technic.chests:register("Iron", {
 	infotext = false,
 	color = false,
 	locked = true,
+    protected = false,
 })
 
+if minetest.get_modpath("protector") then
+    minetest.register_craft({
+        output = 'technic:iron_protected_chest 1',
+        recipe = {
+            {cast_iron_ingot,cast_iron_ingot,cast_iron_ingot},
+            {cast_iron_ingot,'protector:chest',cast_iron_ingot},
+            {cast_iron_ingot,cast_iron_ingot,cast_iron_ingot},
+        }
+    })
+
+    minetest.register_craft({
+        output = 'technic:iron_protected_chest 1',
+        recipe = {
+            {'default:copper_ingot'},
+            {'technic:iron_chest'},
+        }
+    })
+
+    technic.chests:register("Iron", {
+        width = 9,
+        height = 5,
+        sort = true,
+        autosort = false,
+        infotext = false,
+        color = false,
+        locked = false,
+        protected = true,
+    })
+end

--- a/technic_chests/mithril_chest.lua
+++ b/technic_chests/mithril_chest.lua
@@ -16,6 +16,16 @@ if minetest.get_modpath("moreores") then
 			{'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
 		}
 	})
+    if minetest.get_modpath("protector") then
+        minetest.register_craft({
+            output = 'technic:mithril_protected_chest 1',
+            recipe = {
+                {'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
+                {'moreores:mithril_ingot','technic:gold_protected_chest','moreores:mithril_ingot'},
+                {'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
+            }
+        })
+    end
 end
 
 minetest.register_craft({
@@ -34,6 +44,7 @@ technic.chests:register("Mithril", {
 	infotext = false,
 	color = false,
 	locked = false,
+    protected = false,
 })
 
 technic.chests:register("Mithril", {
@@ -44,5 +55,26 @@ technic.chests:register("Mithril", {
 	infotext = false,
 	color = false,
 	locked = true,
+    protected = false,
 })
 
+if minetest.get_modpath("protector") then
+    minetest.register_craft({
+        output = 'technic:mithril_protected_chest 1',
+        recipe = {
+            {'default:copper_ingot'},
+            {'technic:mithril_chest'},
+        }
+    })
+
+    technic.chests:register("Mithril", {
+        width = 15,
+        height = 6,
+        sort = true,
+        autosort = true,
+        infotext = false,
+        color = false,
+        locked = false,
+        protected = true,
+    })
+end

--- a/technic_chests/mithril_chest.lua
+++ b/technic_chests/mithril_chest.lua
@@ -16,16 +16,16 @@ if minetest.get_modpath("moreores") then
 			{'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
 		}
 	})
-    if minetest.get_modpath("protector") then
-        minetest.register_craft({
-            output = 'technic:mithril_protected_chest 1',
-            recipe = {
-                {'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
-                {'moreores:mithril_ingot','technic:gold_protected_chest','moreores:mithril_ingot'},
-                {'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
-            }
-        })
-    end
+	if minetest.get_modpath("protector") then
+		minetest.register_craft({
+			output = 'technic:mithril_protected_chest 1',
+			recipe = {
+				{'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
+				{'moreores:mithril_ingot','technic:gold_protected_chest','moreores:mithril_ingot'},
+				{'moreores:mithril_ingot','moreores:mithril_ingot','moreores:mithril_ingot'},
+			}
+		})
+	end
 end
 
 minetest.register_craft({
@@ -44,7 +44,7 @@ technic.chests:register("Mithril", {
 	infotext = false,
 	color = false,
 	locked = false,
-    protected = false,
+	protected = false,
 })
 
 technic.chests:register("Mithril", {
@@ -55,26 +55,26 @@ technic.chests:register("Mithril", {
 	infotext = false,
 	color = false,
 	locked = true,
-    protected = false,
+	protected = false,
 })
 
 if minetest.get_modpath("protector") then
-    minetest.register_craft({
-        output = 'technic:mithril_protected_chest 1',
-        recipe = {
-            {'default:copper_ingot'},
-            {'technic:mithril_chest'},
-        }
-    })
+	minetest.register_craft({
+		output = 'technic:mithril_protected_chest 1',
+		recipe = {
+			{'default:copper_ingot'},
+			{'technic:mithril_chest'},
+		}
+	})
 
-    technic.chests:register("Mithril", {
-        width = 15,
-        height = 6,
-        sort = true,
-        autosort = true,
-        infotext = false,
-        color = false,
-        locked = false,
-        protected = true,
-    })
+	technic.chests:register("Mithril", {
+		width = 15,
+		height = 6,
+		sort = true,
+		autosort = true,
+		infotext = false,
+		color = false,
+		locked = false,
+		protected = true,
+	})
 end

--- a/technic_chests/mod.conf
+++ b/technic_chests/mod.conf
@@ -1,3 +1,3 @@
 name = technic_chests
 depends = default, basic_materials
-optional_depends = moreblocks, moreores, pipeworks, intllib, tubelib
+optional_depends = moreblocks, moreores, pipeworks, intllib, tubelib, protector

--- a/technic_chests/register.lua
+++ b/technic_chests/register.lua
@@ -173,9 +173,9 @@ local function get_receive_fields(name, data)
 		if data.color then
 			-- This sets the node
 			-- local nn = "technic:"..lname..(data.locked and "_locked" or "").."_chest"
-            local nn = "technic:"..name:lower()..
-                       (data.locked and "_locked" or "")..
-                       (data.protected and "_protected" or "").."_chest"
+			local nn = "technic:"..name:lower()..
+					   (data.locked and "_locked" or "")..
+					   (data.protected and "_protected" or "").."_chest"
 			check_color_buttons(pos, meta, nn, fields)
 		end
 		if fields["fs_helpers_cycling:0:splitstacks"]
@@ -243,14 +243,14 @@ function technic.chests:definition(name, data)
 			pipeworks.after_place(pos)
 		end
 		table.insert(front, "technic_"..lname.."_chest_lock_overlay.png")
-    elseif data.protected then
-        locked_after_place = function(pos, _)
-            local meta = minetest.get_meta(pos)
-            meta:set_string("infotext",
-                    S("%s Protected Chest"):format(name))
-            pipeworks.after_place(pos)
-        end
-    else
+	elseif data.protected then
+		locked_after_place = function(pos, _)
+			local meta = minetest.get_meta(pos)
+			meta:set_string("infotext",
+					S("%s Protected Chest"):format(name))
+			pipeworks.after_place(pos)
+		end
+	else
 		locked_after_place = pipeworks.after_place
 	end
 
@@ -258,8 +258,8 @@ function technic.chests:definition(name, data)
 	if data.locked then
 		desc = S("%s Locked Chest"):format(name)
 	elseif data.protected then
-        desc = S("%s Protected Chest"):format(name)
-    else
+		desc = S("%s Protected Chest"):format(name)
+	else
 		desc = S("%s Chest"):format(name)
 	end
 
@@ -304,10 +304,9 @@ function technic.chests:definition(name, data)
 		on_blast = function(pos)
 			local drops = {}
 			default.get_inventory_drops(pos, "main", drops)
-			-- drops[#drops+1] = "technic:"..name:lower()..(data.locked and "_locked" or "").."_chest"
-            drops[#drops+1] = "technic:"..name:lower()..
-                       (data.locked and "_locked" or "")..
-                       (data.protected and "_protected" or "").."_chest"
+			drops[#drops+1] = "technic:"..name:lower()..
+					   (data.locked and "_locked" or "")..
+					   (data.protected and "_protected" or "").."_chest"
 			minetest.remove_node(pos)
 			return drops
 		end,
@@ -351,27 +350,7 @@ function technic.chests:definition(name, data)
 		def.can_dig = function(pos,player)
 			local meta = minetest.get_meta(pos);
 			local inv = meta:get_inventory()
-			return inv:is_empty("main") and default.can_interact_with_node(player, pos)
-		end
-		def.on_skeleton_key_use = function(pos, player, newsecret)
-			local meta = minetest.get_meta(pos)
-			local owner = meta:get_string("owner")
-			local name = player:get_player_name()
-
-			-- verify placer is owner of lockable chest
-			if owner ~= name then
-				minetest.record_protection_violation(pos, name)
-				minetest.chat_send_player(name, "You do not own this chest.")
-				return nil
-			end
-
-			local secret = meta:get_string("key_lock_secret")
-			if secret == "" then
-				secret = newsecret
-				meta:set_string("key_lock_secret", secret)
-			end
-
-			return secret, "a locked chest", owner
+			return inv:is_empty("main") and not minetest.is_protected(pos, player:get_player_name())
 		end
 	end
 	return def
@@ -411,8 +390,8 @@ function technic.chests:register(name, data)
 	local def = technic.chests:definition(name, data)
 
 	local nn = "technic:"..name:lower()..
-               (data.locked and "_locked" or "")..
-               (data.protected and "_protected" or "").."_chest"
+			   (data.locked and "_locked" or "")..
+			   (data.protected and "_protected" or "").."_chest"
 	minetest.register_node(":"..nn, def)
 
 	if tubelib_exists then

--- a/technic_chests/silver_chest.lua
+++ b/technic_chests/silver_chest.lua
@@ -16,6 +16,17 @@ if minetest.get_modpath("moreores") then
 			{'moreores:silver_ingot','moreores:silver_ingot','moreores:silver_ingot'},
 		}
 	})
+
+    if minetest.get_modpath("protector") then
+        minetest.register_craft({
+            output = 'technic:silver_protected_chest',
+            recipe = {
+                {'moreores:silver_ingot','moreores:silver_ingot','moreores:silver_ingot'},
+                {'moreores:silver_ingot','technic:copper_protected_chest','moreores:silver_ingot'},
+                {'moreores:silver_ingot','moreores:silver_ingot','moreores:silver_ingot'},
+            }
+        })
+    end
 end
 
 minetest.register_craft({
@@ -34,6 +45,7 @@ technic.chests:register("Silver", {
 	infotext = true,
 	color = false,
 	locked = false,
+    protected = false,
 })
 
 technic.chests:register("Silver", {
@@ -44,5 +56,26 @@ technic.chests:register("Silver", {
 	infotext = true,
 	color = false,
 	locked = true,
+    protected = false,
 })
 
+if minetest.get_modpath("protector") then
+    minetest.register_craft({
+        output = 'technic:silver_protected_chest',
+        recipe = {
+            {'default:copper_ingot'},
+            {'technic:silver_chest'},
+        }
+    })
+
+    technic.chests:register("Silver", {
+        width = 12,
+        height = 6,
+        sort = true,
+        autosort = true,
+        infotext = true,
+        color = false,
+        locked = false,
+        protected = true,
+    })
+end

--- a/technic_chests/silver_chest.lua
+++ b/technic_chests/silver_chest.lua
@@ -17,16 +17,16 @@ if minetest.get_modpath("moreores") then
 		}
 	})
 
-    if minetest.get_modpath("protector") then
-        minetest.register_craft({
-            output = 'technic:silver_protected_chest',
-            recipe = {
-                {'moreores:silver_ingot','moreores:silver_ingot','moreores:silver_ingot'},
-                {'moreores:silver_ingot','technic:copper_protected_chest','moreores:silver_ingot'},
-                {'moreores:silver_ingot','moreores:silver_ingot','moreores:silver_ingot'},
-            }
-        })
-    end
+	if minetest.get_modpath("protector") then
+		minetest.register_craft({
+			output = 'technic:silver_protected_chest',
+			recipe = {
+				{'moreores:silver_ingot','moreores:silver_ingot','moreores:silver_ingot'},
+				{'moreores:silver_ingot','technic:copper_protected_chest','moreores:silver_ingot'},
+				{'moreores:silver_ingot','moreores:silver_ingot','moreores:silver_ingot'},
+			}
+		})
+	end
 end
 
 minetest.register_craft({
@@ -45,7 +45,7 @@ technic.chests:register("Silver", {
 	infotext = true,
 	color = false,
 	locked = false,
-    protected = false,
+	protected = false,
 })
 
 technic.chests:register("Silver", {
@@ -56,26 +56,26 @@ technic.chests:register("Silver", {
 	infotext = true,
 	color = false,
 	locked = true,
-    protected = false,
+	protected = false,
 })
 
 if minetest.get_modpath("protector") then
-    minetest.register_craft({
-        output = 'technic:silver_protected_chest',
-        recipe = {
-            {'default:copper_ingot'},
-            {'technic:silver_chest'},
-        }
-    })
+	minetest.register_craft({
+		output = 'technic:silver_protected_chest',
+		recipe = {
+			{'default:copper_ingot'},
+			{'technic:silver_chest'},
+		}
+	})
 
-    technic.chests:register("Silver", {
-        width = 12,
-        height = 6,
-        sort = true,
-        autosort = true,
-        infotext = true,
-        color = false,
-        locked = false,
-        protected = true,
-    })
+	technic.chests:register("Silver", {
+		width = 12,
+		height = 6,
+		sort = true,
+		autosort = true,
+		infotext = true,
+		color = false,
+		locked = false,
+		protected = true,
+	})
 end


### PR DESCRIPTION
Probably there is a lot to improve but here is my first attempt. I added an extra "flavour" of chest: Protected chests. Those are accessible by members of the area when protector mod is being used. Its very useful for teams, when you don't want to make like 20 keys for each person and hope they can manage to remember which key is for which chest.

The code I used to make it compatible with protector was very generic and probably could be used to make it compatible with other protection mods.