### PR TITLE
Fix locked chest recipes (Fixes #544)

### DIFF
--- a/technic_chests/copper_chest.lua
+++ b/technic_chests/copper_chest.lua
@@ -20,8 +20,8 @@ minetest.register_craft({
 	output = 'technic:copper_locked_chest 1',
 	type = "shapeless",
 	recipe = {
-		{'basic_materials:padlock'},
-		{'technic:copper_chest'},
+		'basic_materials:padlock',
+		'technic:copper_chest',
 	}
 })
 

--- a/technic_chests/gold_chest.lua
+++ b/technic_chests/gold_chest.lua
@@ -31,8 +31,8 @@ minetest.register_craft({
 	output = 'technic:gold_locked_chest',
 	type = "shapeless",
 	recipe = {
-		{'basic_materials:padlock'},
-		{'technic:gold_chest'},
+		'basic_materials:padlock',
+		'technic:gold_chest',
 	}
 })
 

--- a/technic_chests/iron_chest.lua
+++ b/technic_chests/iron_chest.lua
@@ -27,8 +27,8 @@ minetest.register_craft({
 	output = 'technic:iron_locked_chest 1',
 	type = "shapeless",
 	recipe = {
-		{'basic_materials:padlock'},
-		{'technic:iron_chest'},
+		'basic_materials:padlock',
+		'technic:iron_chest',
 	}
 })
 

--- a/technic_chests/mithril_chest.lua
+++ b/technic_chests/mithril_chest.lua
@@ -22,8 +22,8 @@ minetest.register_craft({
 	output = 'technic:mithril_locked_chest 1',
 	type = "shapeless",
 	recipe = {
-		{'basic_materials:padlock'},
-		{'technic:mithril_chest'},
+		'basic_materials:padlock',
+		'technic:mithril_chest',
 	}
 })
 

--- a/technic_chests/silver_chest.lua
+++ b/technic_chests/silver_chest.lua
@@ -22,8 +22,8 @@ minetest.register_craft({
 	output = 'technic:silver_locked_chest',
 	type = "shapeless",
 	recipe = {
-		{'basic_materials:padlock'},
-		{'technic:silver_chest'},
+		'basic_materials:padlock',
+		'technic:silver_chest',
 	}
 })
 


### PR DESCRIPTION
Fixes [#544](https://github.com/minetest-mods/technic/issues/544).

I came across the issue with the mod failing to load due to wrong craft recipes for the locked chests. There is an issue opened, however i could not find any pull requests, so i made one.

The shapeless recipes for the locked chests now follow the examples from the official api, this was confirmed to work with 5.2-stable and 5.3-dev versions of minetest.