### PR TITLE
Make drill and laser use the custom on_dig of node(s) it digs

### DIFF
--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -52,17 +52,14 @@ local function drill_dig_it0 (pos,player)
 		return
 	end
 	local node = minetest.get_node(pos)
-    local def = minetest.registered_nodes[node.name]
 	if node.name == "air" or node.name == "ignore" then return end
 	if node.name == "default:lava_source" then return end
 	if node.name == "default:lava_flowing" then return end
 	if node.name == "default:water_source" then minetest.remove_node(pos) return end
 	if node.name == "default:water_flowing" then minetest.remove_node(pos) return end
-    if node.name == "ignore" or not def then
-	    return
-    else 
-        def.on_dig(pos, node, player)
-	end
+    local def = minetest.registered_nodes[node.name]
+    if not def then return end
+    def.on_dig(pos, node, player)
 end
 
 local function drill_dig_it1 (player)

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -57,9 +57,9 @@ local function drill_dig_it0 (pos,player)
 	if node.name == "default:lava_flowing" then return end
 	if node.name == "default:water_source" then minetest.remove_node(pos) return end
 	if node.name == "default:water_flowing" then minetest.remove_node(pos) return end
-    local def = minetest.registered_nodes[node.name]
-    if not def then return end
-    def.on_dig(pos, node, player)
+      local def = minetest.registered_nodes[node.name]
+      if not def then return end
+      def.on_dig(pos, node, player)
 end
 
 local function drill_dig_it1 (player)

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -57,9 +57,9 @@ local function drill_dig_it0 (pos,player)
 	if node.name == "default:lava_flowing" then return end
 	if node.name == "default:water_source" then minetest.remove_node(pos) return end
 	if node.name == "default:water_flowing" then minetest.remove_node(pos) return end
-      local def = minetest.registered_nodes[node.name]
-      if not def then return end
-      def.on_dig(pos, node, player)
+	local def = minetest.registered_nodes[node.name]
+	if not def then return end
+	def.on_dig(pos, node, player)
 end
 
 local function drill_dig_it1 (player)

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -51,13 +51,18 @@ local function drill_dig_it0 (pos,player)
 		minetest.record_protection_violation(pos, player:get_player_name())
 		return
 	end
-	local node=minetest.get_node(pos)
+	local node = minetest.get_node(pos)
+    local def = minetest.registered_nodes[node.name]
 	if node.name == "air" or node.name == "ignore" then return end
 	if node.name == "default:lava_source" then return end
 	if node.name == "default:lava_flowing" then return end
 	if node.name == "default:water_source" then minetest.remove_node(pos) return end
 	if node.name == "default:water_flowing" then minetest.remove_node(pos) return end
-	minetest.node_dig(pos,node,player)
+    if node.name == "ignore" or not def then
+	    return
+    else 
+        def.on_dig(pos, node, player)
+	end
 end
 
 local function drill_dig_it1 (player)

--- a/technic/tools/mining_lasers.lua
+++ b/technic/tools/mining_lasers.lua
@@ -46,7 +46,7 @@ local function laser_node(pos, node, player)
 		})
 		return
 	end
-	minetest.node_dig(pos, node, player)
+	def.on_dig(pos, node, player)
 end
 
 local keep_node = {air = true}


### PR DESCRIPTION
There is a conflict with the `drawers` mod, which means that when the drill takes a drawer, all the items will disappear that *were* in the drawer, and you will get the drawer in your inventory.
Simplest way to fix this for Tunnelers' Abyss was to do this - so porting here. I have not tested if this is true for the mining laser too, yet.