### PR TITLE
add external machine registration support

### DIFF
--- a/technic/machines/register/machine_base.lua
+++ b/technic/machines/register/machine_base.lua
@@ -4,8 +4,6 @@ local S = technic.getter
 local fs_helpers = pipeworks.fs_helpers
 local tube_entry = "^pipeworks_tube_connection_metallic.png"
 
-data.modname = data.modname or "technic"
-
 function technic.default_can_insert(pos, node, stack, direction)
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
@@ -40,6 +38,8 @@ function technic.register_base_machine(data)
 	local machine_desc = data.machine_desc
 	local tier = data.tier
 	local ltier = string.lower(tier)
+	
+	data.modname = data.modname or minetest.get_current_modname()
 
 	local groups = {cracky = 2, technic_machine = 1, ["technic_"..ltier] = 1}
 	if data.tube then

--- a/technic/machines/register/machine_base.lua
+++ b/technic/machines/register/machine_base.lua
@@ -4,6 +4,8 @@ local S = technic.getter
 local fs_helpers = pipeworks.fs_helpers
 local tube_entry = "^pipeworks_tube_connection_metallic.png"
 
+data.modname = data.modname or "technic"
+
 function technic.default_can_insert(pos, node, stack, direction)
 	local meta = minetest.get_meta(pos)
 	local inv = meta:get_inventory()
@@ -82,7 +84,7 @@ function technic.register_base_machine(data)
 		local eu_input = meta:get_int(tier.."_EU_input")
 
 		local machine_desc_tier = machine_desc:format(tier)
-		local machine_node      = "technic:"..ltier.."_"..machine_name
+		local machine_node      = data.modname..":"..ltier.."_"..machine_name
 		local machine_demand    = data.demand
 
 		-- Setup meta data if it does not exist.
@@ -157,15 +159,15 @@ function technic.register_base_machine(data)
 		tentry = ""
 	end
 
-	minetest.register_node("technic:"..ltier.."_"..machine_name, {
+	minetest.register_node(data.modname..":"..ltier.."_"..machine_name, {
 		description = machine_desc:format(tier),
 		tiles = {
-			"technic_"..ltier.."_"..machine_name.."_top.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_bottom.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_side.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_side.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_side.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_front.png"
+			data.modname.."_"..ltier.."_"..machine_name.."_top.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_bottom.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_side.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_side.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_side.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_front.png"
 		},
 		paramtype2 = "facedir",
 		groups = groups,
@@ -227,18 +229,18 @@ function technic.register_base_machine(data)
 		end,
 	})
 
-	minetest.register_node("technic:"..ltier.."_"..machine_name.."_active",{
+	minetest.register_node(data.modname..":"..ltier.."_"..machine_name.."_active",{
 		description = machine_desc:format(tier),
 		tiles = {
-			"technic_"..ltier.."_"..machine_name.."_top.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_bottom.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_side.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_side.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_side.png"..tentry,
-			"technic_"..ltier.."_"..machine_name.."_front_active.png"
+			data.modname.."_"..ltier.."_"..machine_name.."_top.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_bottom.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_side.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_side.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_side.png"..tentry,
+			data.modname.."_"..ltier.."_"..machine_name.."_front_active.png"
 		},
 		paramtype2 = "facedir",
-		drop = "technic:"..ltier.."_"..machine_name,
+		drop = data.modname..":"..ltier.."_"..machine_name,
 		groups = active_groups,
 		connect_sides = data.connect_sides or connect_default,
 		legacy_facedir_simple = true,
@@ -249,7 +251,7 @@ function technic.register_base_machine(data)
 		allow_metadata_inventory_take = technic.machine_inventory_take,
 		allow_metadata_inventory_move = technic.machine_inventory_move,
 		technic_run = run,
-		technic_disabled_machine_name = "technic:"..ltier.."_"..machine_name,
+		technic_disabled_machine_name = data.modname..":"..ltier.."_"..machine_name,
 		on_receive_fields = function(pos, formname, fields, sender)
 			local node = minetest.get_node(pos)
 			if not pipeworks.may_configure(pos, sender) then return end
@@ -271,8 +273,8 @@ function technic.register_base_machine(data)
 		end,
 	})
 
-	technic.register_machine(tier, "technic:"..ltier.."_"..machine_name,            technic.receiver)
-	technic.register_machine(tier, "technic:"..ltier.."_"..machine_name.."_active", technic.receiver)
+	technic.register_machine(tier, data.modname..":"..ltier.."_"..machine_name,            technic.receiver)
+	technic.register_machine(tier, data.modname..":"..ltier.."_"..machine_name.."_active", technic.receiver)
 
 end -- End registration
 


### PR DESCRIPTION
Closes https://github.com/minetest-mods/technic/issues/419
Replaces https://github.com/minetest-mods/technic/pull/420

Does exactly what #420 was supposed to.
To test: Register a machine from a completely different mod and make sure that everything works. 