### PR TITLE
Fix warning reported by LuaCheck

### DIFF
--- a/technic/machines/register/machine_base.lua
+++ b/technic/machines/register/machine_base.lua
@@ -38,7 +38,7 @@ function technic.register_base_machine(data)
 	local machine_desc = data.machine_desc
 	local tier = data.tier
 	local ltier = string.lower(tier)
-	
+
 	data.modname = data.modname or minetest.get_current_modname()
 
 	local groups = {cracky = 2, technic_machine = 1, ["technic_"..ltier] = 1}


### PR DESCRIPTION
Remove whitespace in `technic/machines/register/machine.base.lua`.