### PR TITLE
constructor protection check

### DIFF
--- a/technic/machines/other/constructor.lua
+++ b/technic/machines/other/constructor.lua
@@ -103,7 +103,9 @@ local function make_on(mark, length)
 			minetest.check_for_falling(pos)
 			for i = 1, length do
 				place_pos = vector.add(place_pos, dir)
-				if owner ~= "" and minetest.is_protected(place_pos, owner) then return end
+				if owner ~= "" and minetest.is_protected(place_pos, owner) then
+					return
+				end
 				local place_node = minetest.get_node(place_pos)
 				deploy_node(inv, "slot"..i, place_pos, place_node, node)
 			end
@@ -161,7 +163,7 @@ local function make_constructor(mark, length)
 		end,
 		after_place_node = function(pos, placer)
 			local meta = minetest.get_meta(pos)
-			meta:set_string("owner", placer:get_player_name() or "")
+			meta:set_string("owner", (placer and placer:get_player_name() or ""))
 		end,
 		can_dig = function(pos, player)
 			local meta = minetest.get_meta(pos)

--- a/technic/machines/other/constructor.lua
+++ b/technic/machines/other/constructor.lua
@@ -160,10 +160,11 @@ local function make_constructor(mark, length)
 			for i = 1, length do
 				inv:set_size("slot"..i, 1)
 			end
+			meta:set_string("owner", "?")
 		end,
 		after_place_node = function(pos, placer)
 			local meta = minetest.get_meta(pos)
-			meta:set_string("owner", (placer and placer:get_player_name() or ""))
+			meta:set_string("owner", (placer and placer:get_player_name() or "?"))
 		end,
 		can_dig = function(pos, player)
 			local meta = minetest.get_meta(pos)

--- a/technic/machines/other/constructor.lua
+++ b/technic/machines/other/constructor.lua
@@ -88,6 +88,7 @@ minetest.register_craft({
 local function make_on(mark, length)
 	return function(pos, node)
 		local meta = minetest.get_meta(pos)
+		local owner = meta:get_string("owner")
 		local inv = meta:get_inventory()
 		local dir = vector.new()
 		if node.param2 == 3 then dir.x = 1 end
@@ -102,6 +103,7 @@ local function make_on(mark, length)
 			minetest.check_for_falling(pos)
 			for i = 1, length do
 				place_pos = vector.add(place_pos, dir)
+				if owner ~= "" and minetest.is_protected(place_pos, owner) then return end
 				local place_node = minetest.get_node(place_pos)
 				deploy_node(inv, "slot"..i, place_pos, place_node, node)
 			end
@@ -156,6 +158,10 @@ local function make_constructor(mark, length)
 			for i = 1, length do
 				inv:set_size("slot"..i, 1)
 			end
+		end,
+		after_place_node = function(pos, placer)
+			local meta = minetest.get_meta(pos)
+			meta:set_string("owner", placer:get_player_name() or "")
 		end,
 		can_dig = function(pos, player)
 			local meta = minetest.get_meta(pos)


### PR DESCRIPTION
Check if the player who placed constructor can access protected positions before placing or removing nodes. A mk3 constructor can remove up to 4 nodes into a protection, including chests that contain items. This only fixes the protection bypass, but the constructor should probably call can_dig() before removing nodes to avoid losing items inside inventories.

Existing constructors won't have an owner but will continue to work. Only newly placed constructors will perform the protection check.