### PR TITLE
Restore recipe for bronze block to ingots

### DIFF
--- a/technic/crafts.lua
+++ b/technic/crafts.lua
@@ -7,6 +7,13 @@ minetest.clear_craft({
 	type = "shapeless",
 	output = "default:bronze_ingot"
 })
+-- Restore recipe for bronze block to ingots
+minetest.register_craft({
+	output = "default:bronze_ingot 9",
+	recipe = {
+		{"default:bronzeblock"}
+	}
+})
 
 -- Accelerator tube
 if pipeworks.enable_accelerator_tube then


### PR DESCRIPTION
The minetest.clear_craft() in technic/crafts.lua removes all recipes that output one or more bronze ingots.

Fixes #565.