### PR TITLE
nuclear_reactor: add error messages on start failure

### DIFF
--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -234,7 +234,7 @@ local function start_reactor(pos, meta)
 		end
 	end
 	-- Check that the reactor is complete and has the correct fuel
-	if correct_fuel_count ~= 6 or reactor_structure_badness(pos) ~= 0 then
+	if correct_fuel_count ~= 6 then
 		return msg_fuel_missing
 	end
 

--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -217,7 +217,7 @@ end
 
 
 local function start_reactor(pos, meta)
-    msg_fuel_missing = "Error: You need to insert 6 pieces of Uranium Fuel."
+	local msg_fuel_missing = "Error: You need to insert 6 pieces of Uranium Fuel."
 
 	if minetest.get_node(pos).name ~= "technic:hv_nuclear_reactor_core" then
 		return msg_fuel_missing
@@ -238,9 +238,9 @@ local function start_reactor(pos, meta)
 		return msg_fuel_missing
 	end
 
-    if reactor_structure_badness(pos) ~= 0 then
-        return "Error: The power plant seems to be built incorrectly."
-    end
+	if reactor_structure_badness(pos) ~= 0 then
+		return "Error: The power plant seems to be built incorrectly."
+	end
 
 	meta:set_int("burn_time", 1)
 	technic.swap_node(pos, "technic:hv_nuclear_reactor_core_active")

--- a/technic/machines/HV/nuclear_reactor.lua
+++ b/technic/machines/HV/nuclear_reactor.lua
@@ -217,7 +217,8 @@ end
 
 
 local function start_reactor(pos, meta)
-	local msg_fuel_missing = "Error: You need to insert 6 pieces of Uranium Fuel."
+	local correct_fuel_count = 6
+	local msg_fuel_missing = "Error: You need to insert " .. correct_fuel_count .. " pieces of Uranium Fuel."
 
 	if minetest.get_node(pos).name ~= "technic:hv_nuclear_reactor_core" then
 		return msg_fuel_missing
@@ -227,17 +228,18 @@ local function start_reactor(pos, meta)
 		return msg_fuel_missing
 	end
 	local src_list = inv:get_list("src")
-	local correct_fuel_count = 0
+	local fuel_count = 0
 	for _, src_stack in pairs(src_list) do
 		if src_stack and src_stack:get_name() == fuel_type then
-			correct_fuel_count = correct_fuel_count + 1
+			fuel_count = fuel_count + 1
 		end
 	end
-	-- Check that the reactor is complete and has the correct fuel
-	if correct_fuel_count ~= 6 then
+	-- Check that the has the correct fuel
+	if fuel_count ~= correct_fuel_count then
 		return msg_fuel_missing
 	end
 
+	-- Check that the reactor is complete
 	if reactor_structure_badness(pos) ~= 0 then
 		return "Error: The power plant seems to be built incorrectly."
 	end


### PR DESCRIPTION
I built a nuclear reactor a few days ago - when trying to start it, I just simply got the (pretty much useless) message "Error" printed to the console.

I had to read the source to find out that I actually need to insert 6 pieces of uranium fuel into the reactor (as opposed to just one).

I was hoping to save anyone who wants to build nuclear reactors in the future the trouble of jumping through the same hoops, so here are some slightly more useful error messages.
