### PR TITLE
centrifuge: reduce power by half

### DIFF
--- a/technic/machines/MV/centrifuge.lua
+++ b/technic/machines/MV/centrifuge.lua
@@ -9,7 +9,7 @@ minetest.register_craft({
 
 technic.register_centrifuge({
 	tier = "MV",
-	demand = { 8000, 7000, 6000 },
+	demand = { 4000, 3500, 3000 },
 	speed = 2,
 	upgrade = 1,
 	tube = 1,


### PR DESCRIPTION
I guess the contents of this PR are pretty much self-explanatory, so I'll just share a little bit about why I feel this is more adequate :)

In a typical minetest/technic-game, enriching uranium seems to be the most common use case for centrifuges. For a fully automated uranium processing pipeline (0,0 .. 3,5% fissile uranium dust), a total of 34 centrifuges are required. This is, imo, the only way of enriching uranium to 3,5% without going insane. At this point, as a player, I have expended 136 diamonds just for building centrifuges (4 each) and a ton of effort for actually crafting and hooking up the centrifuges with sorting tubes and the likes.
I feel that, at this point, the game should reward players for putting in the effort into building a machine like this.

The resulting machine, however, then has a typical power consumption of ~100kEU, which is roughly equivalent to the output of a nuclear reactor. In order to satisfy this consumption, the player would need to construct a power plant (using solar panels, water mills etc.) that has the same output as the nuclear reactor they were trying to construct in the first place, which leads the entire project ad absurdum.

I feel that by drastically reducing centrifuge power consumption, progression towards building a nuclear reactor would make a lot more sense. It would still require players to build a sizeable power plant before moving on towards a nuclear reactor, but not one with equivalent power output.