### PR TITLE
Supply converter demands only needed power

### DIFF
--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -133,7 +133,6 @@ local run = function(pos, node, run_stage)
 		enabled = enabled == "1"
 	end
 	enabled = enabled and (meta:get_int("mesecon_mode") == 0 or meta:get_int("mesecon_effect") ~= 0)
-	local demand = enabled and meta:get_int("power") or 0
 
 	local pos_up        = {x=pos.x, y=pos.y+1, z=pos.z}
 	local pos_down      = {x=pos.x, y=pos.y-1, z=pos.z}
@@ -144,14 +143,29 @@ local run = function(pos, node, run_stage)
 	local to   = technic.get_cable_tier(name_down)
 
 	if from and to then
-		local input = meta:get_int(from.."_EU_input")
-		meta:set_int(from.."_EU_demand", demand)
-		meta:set_int(from.."_EU_supply", 0)
-		meta:set_int(to.."_EU_demand", 0)
-		meta:set_int(to.."_EU_supply", input * remain)
-		meta:set_string("infotext", S("@1 (@2 @3 -> @4 @5)", machine_name,
-			technic.EU_string(input), from,
-			technic.EU_string(input * remain), to))
+		local network_hash = technic.cables[minetest.hash_node_position(pos_down)]
+		local network = network_hash and minetest.get_position_from_hash(network_hash)
+		local sw_pos = network and {x=network.x,y=network.y+1,z=network.z}
+		local timeout = 0
+		for tier in pairs(technic.machines) do
+			timeout = math.max(meta:get_int(tier.."_EU_timeout"),timeout)
+		end
+		if timeout > 0 and sw_pos and minetest.get_node(sw_pos).name == "technic:switching_station" then
+			local sw_meta = minetest.get_meta(sw_pos)
+			local demand = enabled and math.min(meta:get_int("power"),
+				100 * math.ceil(sw_meta:get_int("demand") / remain / 100)) or 0
+
+			local input = meta:get_int(from.."_EU_input")
+			meta:set_int(from.."_EU_demand", demand)
+			meta:set_int(from.."_EU_supply", 0)
+			meta:set_int(to.."_EU_demand", 0)
+			meta:set_int(to.."_EU_supply", input * remain)
+			meta:set_string("infotext", S("@1 (@2 @3 -> @4 @5)", machine_name,
+				technic.EU_string(input), from,
+				technic.EU_string(input * remain), to))
+		else
+			meta:set_string("infotext",S("%s Has No Network"):format(machine_name))
+		end
 	else
 		meta:set_string("infotext", S("%s Has Bad Cabling"):format(machine_name))
 		if to then

--- a/technic/machines/supply_converter.lua
+++ b/technic/machines/supply_converter.lua
@@ -120,7 +120,7 @@ local run = function(pos, node, run_stage)
 		return
 	end
 
-	local remain = 0.9
+	local efficiency = 0.9
 	-- Machine information
 	local machine_name  = S("Supply Converter")
 	local meta          = minetest.get_meta(pos)


### PR DESCRIPTION
Partially fixes #576.

Supply converter demands only the needed power to satisfy the demand on the output network. It can still be too much if the output network has other power sources, because supply is not taken in account.

To test it: place a powerful generator at the converter's input and a little machine at it's output. e.g. if the machine consumes 300 EU, the converter will demand 400 EU instead of the maximal power. This enables using the remaining power on the input network.

This is the first time I write Lua, and my first contribution to a Minetest mod so I'm not sure it's ok, but it works on my server.

Edit: it causes a problem: battery boxes are not charged on the output network. To fix that, I think battery boxes should use the same demand/supply system as the other machines. A not fully charged battery box demands a fixed power, and a not empty battery box supplies a fixed power.