### PR TITLE
Allow disabling the steel->wrought iron overrides

### DIFF
--- a/technic_worldgen/config.lua
+++ b/technic_worldgen/config.lua
@@ -6,6 +6,7 @@ local defaults = {
 	enable_granite_generation = "true",
 	enable_marble_generation = "true",
 	enable_rubber_tree_generation = "true",
+	enable_steel_override = "true",
 }
 
 for k, v in pairs(defaults) do

--- a/technic_worldgen/crafts.lua
+++ b/technic_worldgen/crafts.lua
@@ -166,27 +166,29 @@ local function for_each_registered_item(action)
 	end
 end
 
-local steel_to_iron = {}
-for _, i in ipairs({
-	"default:axe_steel",
-	"default:pick_steel",
-	"default:shovel_steel",
-	"default:sword_steel",
-	"doors:door_steel",
-	"farming:hoe_steel",
-	"glooptest:hammer_steel",
-	"glooptest:handsaw_steel",
-	"glooptest:reinforced_crystal_glass",
-	"mesecons_doors:op_door_steel",
-	"mesecons_doors:sig_door_steel",
-	"vessels:steel_bottle",
-}) do
-	steel_to_iron[i] = true
-end
-
-for_each_registered_item(function(item_name)
-	local item_def = minetest.registered_items[item_name]
-	if steel_to_iron[item_name] and string.find(item_def.description, "Steel") then
-		minetest.override_item(item_name, { description = string.gsub(item_def.description, "Steel", S("Iron")) })
+if technic.config:get_bool("enable_steel_override") then
+	local steel_to_iron = {}
+	for _, i in ipairs({
+		"default:axe_steel",
+		"default:pick_steel",
+		"default:shovel_steel",
+		"default:sword_steel",
+		"doors:door_steel",
+		"farming:hoe_steel",
+		"glooptest:hammer_steel",
+		"glooptest:handsaw_steel",
+		"glooptest:reinforced_crystal_glass",
+		"mesecons_doors:op_door_steel",
+		"mesecons_doors:sig_door_steel",
+		"vessels:steel_bottle",
+	}) do
+		steel_to_iron[i] = true
 	end
-end)
+
+	for_each_registered_item(function(item_name)
+		local item_def = minetest.registered_items[item_name]
+		if steel_to_iron[item_name] and string.find(item_def.description, "Steel") then
+			minetest.override_item(item_name, { description = string.gsub(item_def.description, "Steel", S("Iron")) })
+		end
+	end)
+end

--- a/technic_worldgen/crafts.lua
+++ b/technic_worldgen/crafts.lua
@@ -50,11 +50,6 @@ minetest.register_craftitem(":technic:sulfur_lump", {
 
 minetest.register_alias("technic:wrought_iron_ingot", "default:steel_ingot")
 
-minetest.override_item("default:steel_ingot", {
-	description = S("Wrought Iron Ingot"),
-	inventory_image = "technic_wrought_iron_ingot.png",
-})
-
 minetest.register_craftitem(":technic:cast_iron_ingot", {
 	description = S("Cast Iron Ingot"),
 	inventory_image = "technic_cast_iron_ingot.png",
@@ -167,6 +162,11 @@ local function for_each_registered_item(action)
 end
 
 if technic.config:get_bool("enable_steel_override") then
+	minetest.override_item("default:steel_ingot", {
+		description = S("Wrought Iron Ingot"),
+		inventory_image = "technic_wrought_iron_ingot.png",
+	})
+
 	local steel_to_iron = {}
 	for _, i in ipairs({
 		"default:axe_steel",

--- a/technic_worldgen/nodes.lua
+++ b/technic_worldgen/nodes.lua
@@ -104,11 +104,6 @@ minetest.register_node(":technic:lead_block", {
 
 minetest.register_alias("technic:wrought_iron_block", "default:steelblock")
 
-minetest.override_item("default:steelblock", {
-	description = S("Wrought Iron Block"),
-	tiles = { "technic_wrought_iron_block.png" },
-})
-
 minetest.register_node(":technic:cast_iron_block", {
 	description = S("Cast Iron Block"),
 	tiles = { "technic_cast_iron_block.png" },
@@ -156,33 +151,40 @@ local function for_each_registered_node(action)
 	end
 end
 
-for_each_registered_node(function(node_name, node_def)
-	if node_name ~= "default:steelblock" and
-			node_name:find("steelblock", 1, true) and
-			node_def.description:find("Steel", 1, true) then
-		minetest.override_item(node_name, {
-			description = node_def.description:gsub("Steel", S("Wrought Iron")),
-		})
-	end
-	local tiles = node_def.tiles or node_def.tile_images
-	if tiles then
-		local new_tiles = {}
-		local do_override = false
-		if type(tiles) == "string" then
-			tiles = {tiles}
-		end
-		for i, t in ipairs(tiles) do
-			if type(t) == "string" and t == "default_steel_block.png" then
-				do_override = true
-				t = "technic_wrought_iron_block.png"
-			end
-			table.insert(new_tiles, t)
-		end
-		if do_override then
+if technic.config:get_bool("enable_steel_override") then
+	minetest.override_item("default:steelblock", {
+		description = S("Wrought Iron Block"),
+		tiles = { "technic_wrought_iron_block.png" },
+	})
+
+	for_each_registered_node(function(node_name, node_def)
+		if node_name ~= "default:steelblock" and
+				node_name:find("steelblock", 1, true) and
+				node_def.description:find("Steel", 1, true) then
 			minetest.override_item(node_name, {
-				tiles = new_tiles
+				description = node_def.description:gsub("Steel", S("Wrought Iron")),
 			})
 		end
-	end
-end)
+		local tiles = node_def.tiles or node_def.tile_images
+		if tiles then
+			local new_tiles = {}
+			local do_override = false
+			if type(tiles) == "string" then
+				tiles = {tiles}
+			end
+			for i, t in ipairs(tiles) do
+				if type(t) == "string" and t == "default_steel_block.png" then
+					do_override = true
+					t = "technic_wrought_iron_block.png"
+				end
+				table.insert(new_tiles, t)
+			end
+			if do_override then
+				minetest.override_item(node_name, {
+					tiles = new_tiles
+				})
+			end
+		end
+	end)
+end
 


### PR DESCRIPTION
This follows a request by a server owner to have the ability to retain the existing names/textures for "steel" items registered by other mods.
It adds one setting, "enable_steel_override", that when false prevents technic from performing the description and texture overrides on these items. Default is true, which yields the same behavior as previously (that is, the overrides are performed).