### PR TITLE
Make infortext when machines Has no network customizable.

### DIFF
--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -140,6 +140,8 @@ Additional definition fields:
 	* This function is currently used to update the node.
 	  Modders have to manually change the information about supply etc. in the
 	  node metadata.
+* `<itemdef>.technic_disabled_machine_name = "string"`
+	* If this field is defined and machine is not connected to network, node will be swaped to node with name defined in this field.
 * `<itemdef>.technic_on_disable(pos, node)`
 	* This function is currently used to update the node when node is not connected to technic power network.
 	  Modders can use this to do some machine specific operations when no network is aviable.

--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -140,6 +140,9 @@ Additional definition fields:
 	* This function is currently used to update the node.
 	  Modders have to manually change the information about supply etc. in the
 	  node metadata.
+* `<itemdef>.technic_on_disable(pos, node)`
+	* This function is currently used to update the node when node is not connected to technic power network.
+	  Modders can use this to do some machine specific operations when no network is aviable.
 
 ## Node Metadata fields
 Nodes connected to the network will have one or more of these parameters as meta

--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -136,15 +136,15 @@ Additional definition fields:
 	* Specifies how the tool wear level is handled. Available modes:
 		* `"mechanical_wear"`: represents physical damage
 		* `"technic_RE_charge"`: represents electrical charge
-* `<itemdef>.technic_run(pos, node)`
-	* This function is currently used to update the node.
+* `<itemdef>.technic_run = function(pos, node) ...`
+	* This callback is used to update the node.
 	  Modders have to manually change the information about supply etc. in the
 	  node metadata.
 * `<itemdef>.technic_disabled_machine_name = "string"`
-	* If this field is defined and machine is not connected to network, node will be swaped to node with name defined in this field.
-* `<itemdef>.technic_on_disable(pos, node)`
-	* This function is currently used to update the node when node is not connected to technic power network.
-	  Modders can use this to do some machine specific operations when no network is aviable.
+	* Specifies the machine's node name to use when it's not connected connected to a network
+* `<itemdef>.technic_on_disable = function(pos, node) ...`
+	* This callback is run when the machine is no longer connected to a technic-powered network.
+
 
 ## Node Metadata fields
 Nodes connected to the network will have one or more of these parameters as meta

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -465,15 +465,16 @@ minetest.register_abm({
 		for tier, machines in pairs(technic.machines) do
 			if machines[node.name] and switching_station_timeout_count(pos, tier) then
 				local nodedef = minetest.registered_nodes[node.name]
-				if nodedef and nodedef.technic_disabled_machine_name then
-					node.name = nodedef.technic_disabled_machine_name
-					minetest.swap_node(pos, node)
-				elseif nodedef and nodedef.technic_on_disable then
-					nodedef.technic_on_disable(pos, node)
-				end
 				if nodedef then
 					local meta = minetest.get_meta(pos)
 					meta:set_string("infotext", S("%s Has No Network"):format(nodedef.description))
+				end
+				if nodedef and nodedef.technic_disabled_machine_name then
+					node.name = nodedef.technic_disabled_machine_name
+					minetest.swap_node(pos, node)
+				end
+				if nodedef and nodedef.technic_on_disable then
+					nodedef.technic_on_disable(pos, node)
 				end
 			end
 		end


### PR DESCRIPTION
I am working on a mode that allows defining machines which can be powered from more types of power sources. And I come into a problem with automated update of infotext for machines not connected to the technic network.

Default state on infotext:
![screenshot_20210904_170539](https://user-images.githubusercontent.com/17455197/132099153-04c12fdf-7bbf-4b55-841f-5d39f8312d09.png)

Wanted state of infotext, after change.
![screenshot_20210904_170034](https://user-images.githubusercontent.com/17455197/132099151-09312532-a8a3-4d6d-859c-34bdbf58da30.png)

So, I have updated abm function for group:technic_machine to fix it.
