### PR TITLE
Add register_cable_tier API function

### DIFF
--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -35,6 +35,10 @@ Available functions:
 * `technic.is_tier_cable(nodename, tier)`
 	* Tells whether the node `nodename` is the cable of the tier `tier`.
 	* Short version of `technic.get_cable_tier(nodename) == tier`
+* `technic.register_cable_tier(nodename, tier)`
+	* Register user defined cable to list of known tier cables.
+	* `nodename`: string, name of the node
+	* `tier`: string, tier name
 
 
 ## Machines

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -11,6 +11,10 @@ function technic.get_cable_tier(name)
 	return cable_tier[name]
 end
 
+function technic.register_cable_tier(name, tier)
+	cable_tier[name] = tier
+end
+
 local function check_connections(pos)
 	-- Build a table of all machines
 	local machines = {}

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -12,6 +12,9 @@ function technic.get_cable_tier(name)
 end
 
 function technic.register_cable_tier(name, tier)
+	assert(technic.machines[tier], "Tier does not exist")
+	assert(type(name) == "string", "Invalid node name")
+
 	cable_tier[name] = tier
 end
 


### PR DESCRIPTION
Add register_cable_tier API function to allow user defined cables registration.

I need a special cable in "node" for my mod cleanroom, which I am working on.