### PR TITLE
Fix outdated dependency links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ world. A few notable features:
   * Minetest 5.0.0 or newer
   * [Minetest Game](https://github.com/minetest/minetest_game/)
   * [mesecons](https://github.com/minetest-mods/mesecons) -> signalling events
-  * [pipeworks](https://gitlab.com/VanessaE/pipeworks/) -> automation of item transport
+  * [pipeworks](https://github.com/mt-mods/pipeworks) -> automation of item transport
   * [moreores](https://github.com/minetest-mods/moreores/) -> additional ores
-  * [basic_materials](https://gitlab.com/VanessaE/basic_materials) -> basic craft items
-  * Supports [moretrees](https://gitlab.com/VanessaE/moretrees) -> rubber trees
+  * [basic_materials](https://github.com/mt-mods/basic_materials) -> basic craft items
+  * Supports [moretrees](https://github.com/mt-mods/moretrees) -> rubber trees
   * Consult `depends.txt` or `mod.conf` of each mod for further dependency information.
 
 


### PR DESCRIPTION
Some of the dependency links in the README file are outdated and don't work anymore.
It looks like VanessaE has handed them over to `mt-mods` (not to confuse with the official `minetest-mods`).

This PR replaces the outdated link with current ones.
They are now the same as the source links from ContentDB (if anyone has concerns about their correctness):
https://content.minetest.net/packages/mt-mods/pipeworks/
https://content.minetest.net/packages/mt-mods/basic_materials/
https://content.minetest.net/packages/mt-mods/moretrees/