### PR TITLE
Get rid of deprecated metadata

### DIFF
--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -71,7 +71,7 @@ function technic.refill_RE_charge(stack)
 	local max_charge = technic.power_tools[stack:get_name()]
 	if not max_charge then return stack end
 	local meta = technic.get_stack_meta_compat(stack)
-	meta:set_int("charge", max_charge)
+	meta:set_int("technic:charge", max_charge)
 	technic.set_RE_wear(stack, max_charge, max_charge)
 	return stack
 end

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -65,12 +65,24 @@ function technic.swap_node(pos, name)
 end
 
 
+--- Returns the meta of an item
+-- Gets overridden when legacy.lua is loaded
+function technic.get_stack_meta(itemstack)
+	return itemstack:get_meta()
+end
+
+--- Same as technic.get_stack_meta for cans
+function technic.get_stack_meta_cans(itemstack)
+	return itemstack:get_meta()
+end
+
+
 --- Fully charge RE chargeable item.
 -- Must be defined early to reference in item definitions.
 function technic.refill_RE_charge(stack)
 	local max_charge = technic.power_tools[stack:get_name()]
 	if not max_charge then return stack end
-	local meta = technic.get_stack_meta_compat(stack)
+	local meta = technic.get_stack_meta(stack)
 	meta:set_int("technic:charge", max_charge)
 	technic.set_RE_wear(stack, max_charge, max_charge)
 	return stack

--- a/technic/helpers.lua
+++ b/technic/helpers.lua
@@ -70,10 +70,9 @@ end
 function technic.refill_RE_charge(stack)
 	local max_charge = technic.power_tools[stack:get_name()]
 	if not max_charge then return stack end
+	local meta = technic.get_stack_meta_compat(stack)
+	meta:set_int("charge", max_charge)
 	technic.set_RE_wear(stack, max_charge, max_charge)
-	local meta = minetest.deserialize(stack:get_metadata()) or {}
-	meta.charge = max_charge
-	stack:set_metadata(minetest.serialize(meta))
 	return stack
 end
 

--- a/technic/legacy.lua
+++ b/technic/legacy.lua
@@ -55,12 +55,7 @@ function technic.get_stack_meta(itemstack)
 		if legacy_table then
 			local table = meta:to_table()
 			for k, v in pairs(legacy_table) do
-				local legacy_key = technic.legacy_meta_keys[k]
-				if legacy_key then
-					table.fields[legacy_key] = v
-				else
-					table.fields[k] = v
-				end
+				table.fields[technic.legacy_meta_keys[k] or k] = v
 			end
 			meta:from_table(table)
 		end

--- a/technic/legacy.lua
+++ b/technic/legacy.lua
@@ -39,3 +39,33 @@ for i = 0, 64 do
 	minetest.register_alias("technic:lv_cable"..i, "technic:lv_cable")
 end
 
+-- Converts legacy itemstack metadata to itemstack meta and returns the ItemStackMetaRef
+function technic.get_stack_meta_compat(itemstack)
+	local meta = itemstack:get_meta()
+	local metadata = meta:get("")
+	if metadata then
+		local metadata_table = minetest.deserialize(metadata)
+		if metadata_table then
+			local table = meta:to_table()
+			for k, v in pairs(metadata_table) do
+				table.fields[k] = v
+			end
+			meta:from_table(table)
+		end
+		meta:set_string("", "")
+	end
+	return meta
+end
+
+-- Same as technic.get_stack_meta_compat for cans.
+-- (Cans didn't store a serialized table in the metadata, but just a number.)
+function technic.get_stack_meta_compat_cans(itemstack)
+	local meta = itemstack:get_meta()
+	local metadata = meta:get("")
+	if metadata then
+		meta:set_string("can_level", metadata)
+		meta:set_string("", "")
+		return meta
+	end
+	return meta
+end

--- a/technic/legacy.lua
+++ b/technic/legacy.lua
@@ -47,7 +47,7 @@ technic.legacy_meta_keys = {
 }
 
 -- Converts legacy itemstack metadata string to itemstack meta and returns the ItemStackMetaRef
-function technic.get_stack_meta_compat(itemstack)
+function technic.get_stack_meta(itemstack)
 	local meta = itemstack:get_meta()
 	local legacy_string = meta:get("") -- Get deprecated metadata
 	if legacy_string then
@@ -69,9 +69,9 @@ function technic.get_stack_meta_compat(itemstack)
 	return meta
 end
 
--- Same as technic.get_stack_meta_compat for cans.
+-- Same as technic.get_stack_meta for cans.
 -- (Cans didn't store a serialized table in the legacy metadata string, but just a number.)
-function technic.get_stack_meta_compat_cans(itemstack)
+function technic.get_stack_meta_cans(itemstack)
 	local meta = itemstack:get_meta()
 	local legacy_string = meta:get("") -- Get deprecated metadata
 	if legacy_string then

--- a/technic/legacy.lua
+++ b/technic/legacy.lua
@@ -39,6 +39,13 @@ for i = 0, 64 do
 	minetest.register_alias("technic:lv_cable"..i, "technic:lv_cable")
 end
 
+-- Item meta
+
+-- Meta keys that have changed
+technic.legacy_meta_keys = {
+	["charge"] = "technic:charge",
+}
+
 -- Converts legacy itemstack metadata to itemstack meta and returns the ItemStackMetaRef
 function technic.get_stack_meta_compat(itemstack)
 	local meta = itemstack:get_meta()
@@ -48,7 +55,12 @@ function technic.get_stack_meta_compat(itemstack)
 		if metadata_table then
 			local table = meta:to_table()
 			for k, v in pairs(metadata_table) do
-				table.fields[k] = v
+				local legacy_key = technic.legacy_meta_keys[k]
+				if legacy_key then
+					table.fields[legacy_key] = v
+				else
+					table.fields[k] = v
+				end
 			end
 			meta:from_table(table)
 		end

--- a/technic/legacy.lua
+++ b/technic/legacy.lua
@@ -46,15 +46,15 @@ technic.legacy_meta_keys = {
 	["charge"] = "technic:charge",
 }
 
--- Converts legacy itemstack metadata to itemstack meta and returns the ItemStackMetaRef
+-- Converts legacy itemstack metadata string to itemstack meta and returns the ItemStackMetaRef
 function technic.get_stack_meta_compat(itemstack)
 	local meta = itemstack:get_meta()
-	local metadata = meta:get("")
-	if metadata then
-		local metadata_table = minetest.deserialize(metadata)
-		if metadata_table then
+	local legacy_string = meta:get("") -- Get deprecated metadata
+	if legacy_string then
+		local legacy_table = minetest.deserialize(metadata)
+		if legacy_table then
 			local table = meta:to_table()
-			for k, v in pairs(metadata_table) do
+			for k, v in pairs(legacy_table) do
 				local legacy_key = technic.legacy_meta_keys[k]
 				if legacy_key then
 					table.fields[legacy_key] = v
@@ -64,19 +64,19 @@ function technic.get_stack_meta_compat(itemstack)
 			end
 			meta:from_table(table)
 		end
-		meta:set_string("", "")
+		meta:set_string("", "") -- Remove deprecated metadata
 	end
 	return meta
 end
 
 -- Same as technic.get_stack_meta_compat for cans.
--- (Cans didn't store a serialized table in the metadata, but just a number.)
+-- (Cans didn't store a serialized table in the legacy metadata string, but just a number.)
 function technic.get_stack_meta_compat_cans(itemstack)
 	local meta = itemstack:get_meta()
-	local metadata = meta:get("")
-	if metadata then
-		meta:set_string("can_level", metadata)
-		meta:set_string("", "")
+	local legacy_string = meta:get("") -- Get deprecated metadata
+	if legacy_string then
+		meta:set_string("can_level", legacy_string)
+		meta:set_string("", "") -- Remove deprecated metadata
 		return meta
 	end
 	return meta

--- a/technic/legacy.lua
+++ b/technic/legacy.lua
@@ -51,7 +51,7 @@ function technic.get_stack_meta(itemstack)
 	local meta = itemstack:get_meta()
 	local legacy_string = meta:get("") -- Get deprecated metadata
 	if legacy_string then
-		local legacy_table = minetest.deserialize(metadata)
+		local legacy_table = minetest.deserialize(legacy_string)
 		if legacy_table then
 			local table = meta:to_table()
 			for k, v in pairs(legacy_table) do

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -416,7 +416,7 @@ local function default_get_charge(itemstack)
 		return 0, 0
 	end
 	local item_meta = technic.get_stack_meta_compat(itemstack)
-	return item_meta:get_int("charge"), technic.power_tools[tool_name]
+	return item_meta:get_int("technic:charge"), technic.power_tools[tool_name]
 end
 
 local function default_set_charge(itemstack, charge)
@@ -425,7 +425,7 @@ local function default_set_charge(itemstack, charge)
 		technic.set_RE_wear(itemstack, charge, technic.power_tools[tool_name])
 	end
 	local item_meta = technic.get_stack_meta_compat(itemstack)
-	item_meta:set_int("charge", charge)
+	item_meta:set_int("technic:charge", charge)
 end
 
 function technic.charge_tools(meta, batt_charge, charge_step)

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -415,7 +415,7 @@ local function default_get_charge(itemstack)
 	if not technic.power_tools[tool_name] then
 		return 0, 0
 	end
-	local item_meta = technic.get_stack_meta_compat(itemstack)
+	local item_meta = technic.get_stack_meta(itemstack)
 	return item_meta:get_int("technic:charge"), technic.power_tools[tool_name]
 end
 
@@ -424,7 +424,7 @@ local function default_set_charge(itemstack, charge)
 	if technic.power_tools[tool_name] then
 		technic.set_RE_wear(itemstack, charge, technic.power_tools[tool_name])
 	end
-	local item_meta = technic.get_stack_meta_compat(itemstack)
+	local item_meta = technic.get_stack_meta(itemstack)
 	item_meta:set_int("technic:charge", charge)
 end
 

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -415,12 +415,8 @@ local function default_get_charge(itemstack)
 	if not technic.power_tools[tool_name] then
 		return 0, 0
 	end
-	-- Set meta data for the tool if it didn't do it itself
-	local item_meta = minetest.deserialize(itemstack:get_metadata()) or {}
-	if not item_meta.charge then
-		item_meta.charge = 0
-	end
-	return item_meta.charge, technic.power_tools[tool_name]
+	local item_meta = technic.get_stack_meta_compat(itemstack)
+	return item_meta:get_int("charge"), technic.power_tools[tool_name]
 end
 
 local function default_set_charge(itemstack, charge)
@@ -428,9 +424,8 @@ local function default_set_charge(itemstack, charge)
 	if technic.power_tools[tool_name] then
 		technic.set_RE_wear(itemstack, charge, technic.power_tools[tool_name])
 	end
-	local item_meta = minetest.deserialize(itemstack:get_metadata()) or {}
-	item_meta.charge = charge
-	itemstack:set_metadata(minetest.serialize(item_meta))
+	local item_meta = technic.get_stack_meta_compat(itemstack)
+	item_meta:set_int("charge", charge)
 end
 
 function technic.charge_tools(meta, batt_charge, charge_step)

--- a/technic/tools/cans.lua
+++ b/technic/tools/cans.lua
@@ -12,14 +12,6 @@ local function set_can_wear(itemstack, level, max_level)
 	itemstack:set_wear(temp)
 end
 
-local function get_can_level(itemstack)
-	if itemstack:get_metadata() == "" then
-		return 0
-	else
-		return tonumber(itemstack:get_metadata())
-	end
-end
-
 function technic.register_can(d)
 	local data = {}
 	for k, v in pairs(d) do data[k] = v end
@@ -33,7 +25,8 @@ function technic.register_can(d)
 			if pointed_thing.type ~= "node" then return end
 			local node = minetest.get_node(pointed_thing.under)
 			if node.name ~= data.liquid_source_name then return end
-			local charge = get_can_level(itemstack)
+			local meta = technic.get_stack_meta_compat_cans(itemstack)
+			local charge = meta:get_int("can_level")
 			if charge == data.can_capacity then return end
 			if minetest.is_protected(pointed_thing.under, user:get_player_name()) then
 				minetest.log("action", user:get_player_name()..
@@ -44,7 +37,7 @@ function technic.register_can(d)
 			end
 			minetest.remove_node(pointed_thing.under)
 			charge = charge + 1
-			itemstack:set_metadata(tostring(charge))
+			meta:set_int("can_level", charge)
 			set_can_wear(itemstack, charge, data.can_capacity)
 			return itemstack
 		end,
@@ -63,7 +56,8 @@ function technic.register_can(d)
 				-- Try to place node above the pointed source, or abort.
 				if not def.buildable_to or node_name == data.liquid_source_name then return end
 			end
-			local charge = get_can_level(itemstack)
+			local meta = technic.get_stack_meta_compat_cans(itemstack)
+			local charge = meta:get_int("can_level")
 			if charge == 0 then return end
 			if minetest.is_protected(pos, user:get_player_name()) then
 				minetest.log("action", user:get_player_name()..
@@ -74,12 +68,12 @@ function technic.register_can(d)
 			end
 			minetest.set_node(pos, {name=data.liquid_source_name})
 			charge = charge - 1
-			itemstack:set_metadata(tostring(charge))
+			meta:set_int("can_level", charge)
 			set_can_wear(itemstack, charge, data.can_capacity)
 			return itemstack
 		end,
 		on_refill = function(stack)
-			stack:set_metadata(tostring(data.can_capacity))
+			meta:set_int("can_level", data.can_capacity)
 			set_can_wear(stack, data.can_capacity, data.can_capacity)
 			return stack
 		end,

--- a/technic/tools/cans.lua
+++ b/technic/tools/cans.lua
@@ -25,7 +25,7 @@ function technic.register_can(d)
 			if pointed_thing.type ~= "node" then return end
 			local node = minetest.get_node(pointed_thing.under)
 			if node.name ~= data.liquid_source_name then return end
-			local meta = technic.get_stack_meta_compat_cans(itemstack)
+			local meta = technic.get_stack_meta_cans(itemstack)
 			local charge = meta:get_int("can_level")
 			if charge == data.can_capacity then return end
 			if minetest.is_protected(pointed_thing.under, user:get_player_name()) then
@@ -56,7 +56,7 @@ function technic.register_can(d)
 				-- Try to place node above the pointed source, or abort.
 				if not def.buildable_to or node_name == data.liquid_source_name then return end
 			end
-			local meta = technic.get_stack_meta_compat_cans(itemstack)
+			local meta = technic.get_stack_meta_cans(itemstack)
 			local charge = meta:get_int("can_level")
 			if charge == 0 then return end
 			if minetest.is_protected(pos, user:get_player_name()) then
@@ -73,7 +73,7 @@ function technic.register_can(d)
 			return itemstack
 		end,
 		on_refill = function(stack)
-			local meta = technic.get_stack_meta_compat_cans(stack)
+			local meta = technic.get_stack_meta_cans(stack)
 			meta:set_int("can_level", data.can_capacity)
 			set_can_wear(stack, data.can_capacity, data.can_capacity)
 			return stack

--- a/technic/tools/cans.lua
+++ b/technic/tools/cans.lua
@@ -73,6 +73,7 @@ function technic.register_can(d)
 			return itemstack
 		end,
 		on_refill = function(stack)
+			local meta = technic.get_stack_meta_compat_cans(stack)
 			meta:set_int("can_level", data.can_capacity)
 			set_can_wear(stack, data.can_capacity, data.can_capacity)
 			return stack

--- a/technic/tools/chainsaw.lua
+++ b/technic/tools/chainsaw.lua
@@ -313,7 +313,7 @@ minetest.register_tool("technic:chainsaw", {
 			return itemstack
 		end
 
-		local meta = technic.get_stack_meta_compat(itemstack)
+		local meta = technic.get_stack_meta(itemstack)
 		local charge = meta:get_int("technic:charge")
 
 		local name = user:get_player_name()

--- a/technic/tools/chainsaw.lua
+++ b/technic/tools/chainsaw.lua
@@ -313,10 +313,8 @@ minetest.register_tool("technic:chainsaw", {
 			return itemstack
 		end
 
-		local meta = minetest.deserialize(itemstack:get_metadata())
-		if not meta or not meta.charge then
-			return
-		end
+		local meta = technic.get_stack_meta_compat(itemstack)
+		local charge = meta:get_int("charge")
 
 		local name = user:get_player_name()
 		if minetest.is_protected(pointed_thing.under, name) then
@@ -326,14 +324,14 @@ minetest.register_tool("technic:chainsaw", {
 
 		-- Send current charge to digging function so that the
 		-- chainsaw will stop after digging a number of nodes
-		chainsaw_dig(user, pointed_thing.under, meta.charge)
-		meta.charge = cutter.charge
+		chainsaw_dig(user, pointed_thing.under, charge)
+		charge = cutter.charge
 
 		cutter = {} -- Free RAM
 
 		if not technic.creative_mode then
-			technic.set_RE_wear(itemstack, meta.charge, chainsaw_max_charge)
-			itemstack:set_metadata(minetest.serialize(meta))
+			meta:set_int("charge", charge)
+			technic.set_RE_wear(itemstack, charge, chainsaw_max_charge)
 		end
 		return itemstack
 	end,

--- a/technic/tools/chainsaw.lua
+++ b/technic/tools/chainsaw.lua
@@ -314,7 +314,7 @@ minetest.register_tool("technic:chainsaw", {
 		end
 
 		local meta = technic.get_stack_meta_compat(itemstack)
-		local charge = meta:get_int("charge")
+		local charge = meta:get_int("technic:charge")
 
 		local name = user:get_player_name()
 		if minetest.is_protected(pointed_thing.under, name) then
@@ -330,7 +330,7 @@ minetest.register_tool("technic:chainsaw", {
 		cutter = {} -- Free RAM
 
 		if not technic.creative_mode then
-			meta:set_int("charge", charge)
+			meta:set_int("technic:charge", charge)
 			technic.set_RE_wear(itemstack, charge, chainsaw_max_charge)
 		end
 		return itemstack

--- a/technic/tools/flashlight.lua
+++ b/technic/tools/flashlight.lua
@@ -39,11 +39,11 @@ local function check_for_flashlight(player)
 	for i = 1, 8 do
 		if hotbar[i]:get_name() == "technic:flashlight" then
 			local meta = technic.get_stack_meta_compat(hotbar[i])
-			local charge = meta:get_int("charge")
+			local charge = meta:get_int("technic:charge")
 			if charge >= 2 then
 				if not technic.creative_mode then
 					charge = charge - 2;
-					meta:set_int("charge", charge)
+					meta:set_int("technic:charge", charge)
 					technic.set_RE_wear(hotbar[i], charge, flashlight_max_charge)
 					inv:set_stack("main", i, hotbar[i])
 				end

--- a/technic/tools/flashlight.lua
+++ b/technic/tools/flashlight.lua
@@ -38,12 +38,13 @@ local function check_for_flashlight(player)
 	local hotbar = inv:get_list("main")
 	for i = 1, 8 do
 		if hotbar[i]:get_name() == "technic:flashlight" then
-			local meta = minetest.deserialize(hotbar[i]:get_metadata())
-			if meta and meta.charge and meta.charge >= 2 then
+			local meta = technic.get_stack_meta_compat(hotbar[i])
+			local charge = meta:get_int("charge")
+			if charge >= 2 then
 				if not technic.creative_mode then
-					meta.charge = meta.charge - 2;
-					technic.set_RE_wear(hotbar[i], meta.charge, flashlight_max_charge)
-					hotbar[i]:set_metadata(minetest.serialize(meta))
+					charge = charge - 2;
+					meta:set_int("charge", charge)
+					technic.set_RE_wear(hotbar[i], charge, flashlight_max_charge)
 					inv:set_stack("main", i, hotbar[i])
 				end
 				return true

--- a/technic/tools/flashlight.lua
+++ b/technic/tools/flashlight.lua
@@ -38,7 +38,7 @@ local function check_for_flashlight(player)
 	local hotbar = inv:get_list("main")
 	for i = 1, 8 do
 		if hotbar[i]:get_name() == "technic:flashlight" then
-			local meta = technic.get_stack_meta_compat(hotbar[i])
+			local meta = technic.get_stack_meta(hotbar[i])
 			local charge = meta:get_int("technic:charge")
 			if charge >= 2 then
 				if not technic.creative_mode then

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -279,7 +279,7 @@ local function mining_drill_mkX_handler(itemstack, user, pointed_thing, drill_ty
 		return
 	end
 
-	local charge = meta:get_int("charge")
+	local charge = meta:get_int("technic:charge")
 	local mode = meta:contains("mode") and meta:get_int("mode") or 1
 
 	-- Check whether the tool has enough charge
@@ -292,7 +292,7 @@ local function mining_drill_mkX_handler(itemstack, user, pointed_thing, drill_ty
 	local pos = minetest.get_pointed_thing_position(pointed_thing, false)
 	drill_dig_it(pos, user, mode)
 	if not technic.creative_mode then
-		meta:set_int("charge", charge)
+		meta:set_int("technic:charge", charge)
 		technic.set_RE_wear(itemstack, charge, max_charge[drill_type])
 	end
 	return itemstack

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -248,7 +248,7 @@ end
 
 local function mining_drill_mkX_setmode(user, itemstack, drill_type, max_modes)
 	local player_name = user:get_player_name()
-	local meta = technic.get_stack_meta_compat(itemstack)
+	local meta = technic.get_stack_meta(itemstack)
 
 	if not meta:contains("mode") then
 		minetest.chat_send_player(player_name,
@@ -267,7 +267,7 @@ end
 
 local function mining_drill_mkX_handler(itemstack, user, pointed_thing, drill_type, max_modes)
 	local keys = user:get_player_control()
-	local meta = technic.get_stack_meta_compat(itemstack)
+	local meta = technic.get_stack_meta(itemstack)
 
 	-- Mode switching (if possible)
 	if max_modes > 1 then

--- a/technic/tools/mining_drill.lua
+++ b/technic/tools/mining_drill.lua
@@ -292,6 +292,7 @@ local function mining_drill_mkX_handler(itemstack, user, pointed_thing, drill_ty
 	local pos = minetest.get_pointed_thing_position(pointed_thing, false)
 	drill_dig_it(pos, user, mode)
 	if not technic.creative_mode then
+		charge = charge - charge_to_take
 		meta:set_int("technic:charge", charge)
 		technic.set_RE_wear(itemstack, charge, max_charge[drill_type])
 	end

--- a/technic/tools/mining_lasers.lua
+++ b/technic/tools/mining_lasers.lua
@@ -101,7 +101,7 @@ for _, m in pairs(mining_lasers_list) do
 		wear_represents = "technic_RE_charge",
 		on_refill = technic.refill_RE_charge,
 		on_use = function(itemstack, user)
-			local meta = technic.get_stack_meta_compat(itemstack)
+			local meta = technic.get_stack_meta(itemstack)
 			local charge = meta:get_int("technic:charge")
 			if charge == 0 then
 				return

--- a/technic/tools/mining_lasers.lua
+++ b/technic/tools/mining_lasers.lua
@@ -101,25 +101,26 @@ for _, m in pairs(mining_lasers_list) do
 		wear_represents = "technic_RE_charge",
 		on_refill = technic.refill_RE_charge,
 		on_use = function(itemstack, user)
-			local meta = minetest.deserialize(itemstack:get_metadata())
-			if not meta or not meta.charge or meta.charge == 0 then
+			local meta = technic.get_stack_meta_compat(itemstack)
+			local charge = meta:get_int("charge")
+			if charge == 0 then
 				return
 			end
 
 			local range = m[2]
-			if meta.charge < m[4] then
+			if charge < m[4] then
 				if not allow_entire_discharging then
 					return
 				end
 				-- If charge is too low, give the laser a shorter range
-				range = range * meta.charge / m[4]
+				range = range * charge / m[4]
 			end
 			laser_shoot(user, range, "technic_laser_beam_mk" .. m[1] .. ".png",
 				"technic_laser_mk" .. m[1])
 			if not technic.creative_mode then
-				meta.charge = math.max(meta.charge - m[4], 0)
-				technic.set_RE_wear(itemstack, meta.charge, m[3])
-				itemstack:set_metadata(minetest.serialize(meta))
+				charge = math.max(charge - m[4], 0)
+				meta:set_int("charge", charge)
+				technic.set_RE_wear(itemstack, charge, m[3])
 			end
 			return itemstack
 		end,

--- a/technic/tools/mining_lasers.lua
+++ b/technic/tools/mining_lasers.lua
@@ -102,7 +102,7 @@ for _, m in pairs(mining_lasers_list) do
 		on_refill = technic.refill_RE_charge,
 		on_use = function(itemstack, user)
 			local meta = technic.get_stack_meta_compat(itemstack)
-			local charge = meta:get_int("charge")
+			local charge = meta:get_int("technic:charge")
 			if charge == 0 then
 				return
 			end
@@ -119,7 +119,7 @@ for _, m in pairs(mining_lasers_list) do
 				"technic_laser_mk" .. m[1])
 			if not technic.creative_mode then
 				charge = math.max(charge - m[4], 0)
-				meta:set_int("charge", charge)
+				meta:set_int("technic:charge", charge)
 				technic.set_RE_wear(itemstack, charge, m[3])
 			end
 			return itemstack

--- a/technic/tools/prospector.lua
+++ b/technic/tools/prospector.lua
@@ -22,7 +22,7 @@ minetest.register_tool("technic:prospector", {
 	on_use = function(toolstack, user, pointed_thing)
 		if not user or not user:is_player() or user.is_fake_player then return end
 		if pointed_thing.type ~= "node" then return end
-		local meta = technic.get_stack_meta_compat(toolstack)
+		local meta = technic.get_stack_meta(toolstack)
 		local toolmeta = meta_to_table(meta)
 		local look_diameter = toolmeta.look_radius * 2 + 1
 		local charge_to_take = toolmeta.look_depth * (toolmeta.look_depth + 1) * look_diameter * look_diameter
@@ -80,7 +80,7 @@ minetest.register_tool("technic:prospector", {
 	end,
 	on_place = function(toolstack, user, pointed_thing)
 		if not user or not user:is_player() or user.is_fake_player then return end
-		local meta = technic.get_stack_meta_compat(toolstack)
+		local meta = technic.get_stack_meta(toolstack)
 		local toolmeta = meta_to_table(meta)
 		local pointed
 		if pointed_thing.type == "node" then
@@ -129,7 +129,7 @@ minetest.register_on_player_receive_fields(function(user, formname, fields)
 	if not user or not user:is_player() or user.is_fake_player then return end
 	local toolstack = user:get_wielded_item()
 	if toolstack:get_name() ~= "technic:prospector" then return true end
-	local meta = technic.get_stack_meta_compat(toolstack)
+	local meta = technic.get_stack_meta(toolstack)
 	for field, value in pairs(fields) do
 		if field:sub(1, 7) == "target_" then
 			meta:set_string("target", field:sub(8))

--- a/technic/tools/prospector.lua
+++ b/technic/tools/prospector.lua
@@ -7,7 +7,7 @@ local function meta_to_table(meta)
 	local t = {}
 	local mt = meta:to_table()
 
-	t.charge = tonumber(mt.fields.charge) or 0
+	t.charge = tonumber(mt.fields["technic:charge"]) or 0
 	t.target = mt.fields.target or ""
 	t.look_depth = tonumber(mt.fields.look_depth) or 7
 	t.look_radius = tonumber(mt.fields.look_radius) or 1
@@ -33,7 +33,7 @@ minetest.register_tool("technic:prospector", {
 		end
 		if not technic.creative_mode then
 			toolmeta.charge = toolmeta.charge - charge_to_take
-			meta:set_int("charge", toolmeta.charge)
+			meta:set_int("technic:charge", toolmeta.charge)
 			technic.set_RE_wear(toolstack, toolmeta.charge, technic.power_tools[toolstack:get_name()])
 		end
 		-- What in the heaven's name is this evil sorcery ?

--- a/technic/tools/sonic_screwdriver.lua
+++ b/technic/tools/sonic_screwdriver.lua
@@ -41,8 +41,9 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 	-- contrary to the default screwdriver, do not check for can_dig, to allow rotating machines with CLU's in them
 	-- this is consistent with the previous sonic screwdriver
 
-	local meta1 = minetest.deserialize(itemstack:get_metadata())
-	if not meta1 or not meta1.charge or meta1.charge < 100 then
+	local meta = technic.get_stack_meta_compat(itemstack)
+	local charge = meta:get_int("charge")
+	if charge < 100 then
 		return
 	end
 
@@ -64,9 +65,9 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 	minetest.swap_node(pos, node)
 
 	if not technic.creative_mode then
-		meta1.charge = meta1.charge - 100
-		itemstack:set_metadata(minetest.serialize(meta1))
-		technic.set_RE_wear(itemstack, meta1.charge, sonic_screwdriver_max_charge)
+		charge = charge - 100
+		meta:set_int("charge", charge)
+		technic.set_RE_wear(itemstack, charge, sonic_screwdriver_max_charge)
 	end
 
 	return itemstack

--- a/technic/tools/sonic_screwdriver.lua
+++ b/technic/tools/sonic_screwdriver.lua
@@ -41,7 +41,7 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 	-- contrary to the default screwdriver, do not check for can_dig, to allow rotating machines with CLU's in them
 	-- this is consistent with the previous sonic screwdriver
 
-	local meta = technic.get_stack_meta_compat(itemstack)
+	local meta = technic.get_stack_meta(itemstack)
 	local charge = meta:get_int("technic:charge")
 	if charge < 100 then
 		return

--- a/technic/tools/sonic_screwdriver.lua
+++ b/technic/tools/sonic_screwdriver.lua
@@ -42,7 +42,7 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 	-- this is consistent with the previous sonic screwdriver
 
 	local meta = technic.get_stack_meta_compat(itemstack)
-	local charge = meta:get_int("charge")
+	local charge = meta:get_int("technic:charge")
 	if charge < 100 then
 		return
 	end
@@ -66,7 +66,7 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 
 	if not technic.creative_mode then
 		charge = charge - 100
-		meta:set_int("charge", charge)
+		meta:set_int("technic:charge", charge)
 		technic.set_RE_wear(itemstack, charge, sonic_screwdriver_max_charge)
 	end
 

--- a/technic/tools/vacuum.lua
+++ b/technic/tools/vacuum.lua
@@ -14,24 +14,23 @@ minetest.register_tool("technic:vacuum", {
 	wear_represents = "technic_RE_charge",
 	on_refill = technic.refill_RE_charge,
 	on_use = function(itemstack, user, pointed_thing)
-		local meta = minetest.deserialize(itemstack:get_metadata())
-		if not meta or not meta.charge then
+		local meta = technic.get_stack_meta_compat(itemstack)
+		local charge = meta:get_int("charge")
+		if charge < vacuum_charge_per_object then
 			return
 		end
-		if meta.charge > vacuum_charge_per_object then
-			minetest.sound_play("vacuumcleaner", {
-				to_player = user:get_player_name(),
-				gain = 0.4,
-			})
-		end
+		minetest.sound_play("vacuumcleaner", {
+			to_player = user:get_player_name(),
+			gain = 0.4,
+		})
 		local pos = user:get_pos()
 		local inv = user:get_inventory()
 		for _, object in ipairs(minetest.get_objects_inside_radius(pos, vacuum_range)) do
 			local luaentity = object:get_luaentity()
 			if not object:is_player() and luaentity and luaentity.name == "__builtin:item" and luaentity.itemstring ~= "" then
 				if inv and inv:room_for_item("main", ItemStack(luaentity.itemstring)) then
-					meta.charge = meta.charge - vacuum_charge_per_object
-					if meta.charge < vacuum_charge_per_object then
+					charge = charge - vacuum_charge_per_object
+					if charge < vacuum_charge_per_object then
 						return
 					end
 					inv:add_item("main", ItemStack(luaentity.itemstring))
@@ -45,8 +44,8 @@ minetest.register_tool("technic:vacuum", {
 			end
 		end
 
-		technic.set_RE_wear(itemstack, meta.charge, vacuum_max_charge)
-		itemstack:set_metadata(minetest.serialize(meta))
+		meta:set_int("charge", charge)
+		technic.set_RE_wear(itemstack, charge, vacuum_max_charge)
 		return itemstack
 	end,
 })

--- a/technic/tools/vacuum.lua
+++ b/technic/tools/vacuum.lua
@@ -15,7 +15,7 @@ minetest.register_tool("technic:vacuum", {
 	on_refill = technic.refill_RE_charge,
 	on_use = function(itemstack, user, pointed_thing)
 		local meta = technic.get_stack_meta_compat(itemstack)
-		local charge = meta:get_int("charge")
+		local charge = meta:get_int("technic:charge")
 		if charge < vacuum_charge_per_object then
 			return
 		end
@@ -44,7 +44,7 @@ minetest.register_tool("technic:vacuum", {
 			end
 		end
 
-		meta:set_int("charge", charge)
+		meta:set_int("technic:charge", charge)
 		technic.set_RE_wear(itemstack, charge, vacuum_max_charge)
 		return itemstack
 	end,

--- a/technic/tools/vacuum.lua
+++ b/technic/tools/vacuum.lua
@@ -14,7 +14,7 @@ minetest.register_tool("technic:vacuum", {
 	wear_represents = "technic_RE_charge",
 	on_refill = technic.refill_RE_charge,
 	on_use = function(itemstack, user, pointed_thing)
-		local meta = technic.get_stack_meta_compat(itemstack)
+		local meta = technic.get_stack_meta(itemstack)
 		local charge = meta:get_int("technic:charge")
 		if charge < vacuum_charge_per_object then
 			return


### PR DESCRIPTION
This solves a part of #601

The deprecated metadata gets converted to a proper ItemStackMetaRef.
All keys stay the same except for:
- Cans that use `can_level` now, since they didn't store a serialized table in the metadata before.
- `charge` which is now `technic:charge`, since any item (also from other mods) may have a technic charge which can cause compatibility problems.

(For other keys e.g. `mode`, the key is special to the item and not universally used, which is not that problematic, I guess.)

There is now only one place left where metadata is used, the sorting function of techinc chests:
https://github.com/minetest-mods/technic/blob/5826c2feaa5aea2ade07af93cfec05952470c17b/technic_chests/register.lua#L149-L150
However, I'm unsure how this should be changed.
Getting the whole stack meta as a table and use the amount of keys or a serialized version to sort, may be an option, but I don't think it is justified performance-wise.
## To do

This PR is a Ready for Review.

(Maybe change the techinc chests sorting function.)


## How to test

1. Start a game with the old version and get some tools, charge them up, change their modes, fill up some cans.
2. Switch to the new version and see if the tools still work as expected.

I tested it, and didn't find any problem, but I'm not sure if I missed something.

## Compatibility note
Other mods which directly accessed the item metadata of technic items will not work anymore.

