### PR TITLE
Feature/add grinder from everness desert stone

### DIFF
--- a/technic/machines/LV/grinder.lua
+++ b/technic/machines/LV/grinder.lua
@@ -9,5 +9,25 @@ minetest.register_craft({
 	}
 })
 
+if (minetest.get_modpath('everness')) then
+	minetest.register_craft({
+		output = 'technic:lv_grinder',
+		recipe = {
+			{'everness:coral_desert_stone', 'default:diamond',        'everness:coral_desert_stone'},
+			{'everness:coral_desert_stone', 'technic:machine_casing', 'everness:coral_desert_stone'},
+			{'technic:granite',      'technic:lv_cable',       'technic:granite'},
+		}
+	})
+
+	minetest.register_craft({
+		output = 'technic:lv_grinder',
+		recipe = {
+			{'everness:forsaken_desert_stone', 'default:diamond',        'everness:forsaken_desert_stone'},
+			{'everness:forsaken_desert_stone', 'technic:machine_casing', 'everness:forsaken_desert_stone'},
+			{'technic:granite',      'technic:lv_cable',       'technic:granite'},
+		}
+	})
+end
+
 technic.register_grinder({tier="LV", demand={200}, speed=1})
 

--- a/technic/machines/LV/grinder.lua
+++ b/technic/machines/LV/grinder.lua
@@ -15,7 +15,7 @@ if (minetest.get_modpath('everness')) then
 		recipe = {
 			{'everness:coral_desert_stone', 'default:diamond',        'everness:coral_desert_stone'},
 			{'everness:coral_desert_stone', 'technic:machine_casing', 'everness:coral_desert_stone'},
-			{'technic:granite',      'technic:lv_cable',       'technic:granite'},
+			{'technic:granite',             'technic:lv_cable',       'technic:granite'},
 		}
 	})
 
@@ -24,7 +24,7 @@ if (minetest.get_modpath('everness')) then
 		recipe = {
 			{'everness:forsaken_desert_stone', 'default:diamond',        'everness:forsaken_desert_stone'},
 			{'everness:forsaken_desert_stone', 'technic:machine_casing', 'everness:forsaken_desert_stone'},
-			{'technic:granite',      'technic:lv_cable',       'technic:granite'},
+			{'technic:granite',                'technic:lv_cable',       'technic:granite'},
 		}
 	})
 end


### PR DESCRIPTION
Hi,

Another little Everness-addition. Everness has its own desert biomes, with their own types of desert stone. Since desert stone is needed to craft the LV grinder, I added the two types of Everness desert stones too as alternative crafting recipes for the LV grinder if the Everness mod is found to be present, so those can be used too (otherwise, if one is using the Everness mod, extremely long trips might be needed to find some `default:desert_stone`.