### PR TITLE
Feature/add compressor recipes for nether brick and lump

### DIFF
--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -11,7 +11,7 @@ end
 -- Function for cases where multiple mods exist with the same name,
 -- to check if we have the right one.
 local function is_right_mod(dependency)
-	local is_right = true
+	is_right = true
 
 	if dependency == "nether" then
 		is_right = minetest.registered_nodes["nether:brick_compressed"] ~= nil

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -38,7 +38,18 @@ if minetest.get_modpath("everness") then
 	end
 end
 
--- defuse the default sandstone recipe, since we have the compressor to take over in a more realistic manner
+if minetest.get_modpath("nether") then
+	local nether_brick_and_lump_recipes = {
+		{"nether:brick 9",				"nether:brick_compressed"},
+		{"nether:brick_compressed 9",	"nether:nether_lump"},
+	}
+
+	for _, data in ipairs(nether_brick_and_lump_recipes) do
+		table.insert(recipes, {data[1], data[2]})
+	end
+end
+
+-- Defuse the default sandstone recipes, since we have the compressor to take over in a more realistic manner.
 local crafts_to_clear = {
 	"default:desert_sand",
 	"default:sand",
@@ -70,6 +81,26 @@ for _, sand_name in ipairs(crafts_to_clear) do
 			{sand_name, sand_name},
 		},
 	})
+end
+
+if minetest.get_modpath("nether") then
+	-- Defuse the default compressed nether brick and nether lump recipes,
+	-- since we have the compressor to take over in a more realistic manner.
+	local nether_crafts_to_clear = {
+		"nether:brick",
+		"nether:brick_compressed",
+	}
+
+	for _, nether_brick_name in ipairs(nether_crafts_to_clear) do
+		minetest.clear_craft({
+			type = "shaped",
+			recipe = {
+				{nether_brick_name, nether_brick_name, nether_brick_name},
+				{nether_brick_name, nether_brick_name, nether_brick_name},
+				{nether_brick_name, nether_brick_name, nether_brick_name},
+			},
+		})
+	end
 end
 
 for _, data in pairs(recipes) do

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -8,6 +8,18 @@ function technic.register_compressor_recipe(data)
 	technic.register_recipe("compressing", data)
 end
 
+-- Function for cases where multiple mods exist with the same name,
+-- to check if we have the right one.
+local function is_right_mod(dependency)
+	is_right = true
+
+	if dependency == "nether" then
+		is_right = minetest.registered_nodes["nether:brick_compressed"] ~= nil
+	end
+
+	return is_right
+end
+
 -- Defuse the default recipes, since we have
 -- the compressor to take over in a more realistic manner.
 local crafts_to_clear = {
@@ -36,7 +48,7 @@ local dependent_crafts_to_clear = {
 -- Add dependent recipes to main collection of
 -- recipes to be cleared if their mods are used.
 for dependency, crafts in pairs(dependent_crafts_to_clear) do
-	if minetest.get_modpath(dependency) then
+	if minetest.get_modpath(dependency) and is_right_mod(dependency) then
 		for _, craft_entry in ipairs(crafts) do
 			table.insert(crafts_to_clear, craft_entry)
 		end
@@ -104,7 +116,7 @@ local dependent_recipes = {
 -- Add dependent recipes to main recipe collection
 -- if their mods are used.
 for dependency, recipes_to_add in pairs(dependent_recipes) do
-	if minetest.get_modpath(dependency) then
+	if minetest.get_modpath(dependency) and is_right_mod(dependency) then
 		for _, recipe_entry in ipairs(recipes_to_add) do
 			table.insert(recipes, recipe_entry)
 		end

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -8,6 +8,69 @@ function technic.register_compressor_recipe(data)
 	technic.register_recipe("compressing", data)
 end
 
+-- Defuse the default recipes, since we have
+-- the compressor to take over in a more realistic manner.
+local crafts_to_clear = {
+	"default:desert_sand",
+	"default:sand",
+	"default:silver_sand",
+}
+
+local dependent_crafts_to_clear = {
+	everness = {
+		"everness:coral_sand",
+		"everness:coral_forest_deep_ocean_sand",
+		"everness:coral_white_sand",
+		"everness:crystal_sand",
+		"everness:cursed_sand",
+		"everness:cursed_lands_deep_ocean_sand",
+		"everness:crystal_forest_deep_ocean_sand",
+		"everness:mineral_sand",
+	},
+	nether = {
+		"nether:brick",
+		"nether:brick_compressed",
+	},
+}
+
+-- Add dependent recipes to main collection of
+-- recipes to be cleared if their mods are used.
+for dependency, crafts in pairs(dependent_crafts_to_clear) do
+	if minetest.get_modpath(dependency) then
+		for _, craft_entry in ipairs(crafts) do
+			table.insert(crafts_to_clear, craft_entry)
+		end
+	end
+end
+
+-- Clear recipes
+for _, craft_name in ipairs(crafts_to_clear) do
+	is_regular = string.sub(craft_name, 1, 7) ~= "nether:"
+
+	if is_regular then
+		-- Regular compression recipes use 2x2 shape.
+		shaped_recipe = {
+			{craft_name, craft_name},
+			{craft_name, craft_name},
+		}
+	else
+		-- Nether's compression recipes use 3x3 shape.
+		shaped_recipe = {
+			{craft_name, craft_name, craft_name},
+			{craft_name, craft_name, craft_name},
+			{craft_name, craft_name, craft_name},
+		}
+	end
+
+	minetest.clear_craft({
+		type = "shaped",
+		recipe = shaped_recipe,
+	})
+end
+
+--
+-- Compile compressor recipes
+--
 local recipes = {
 	{"default:snowblock",          "default:ice"},
 	{"default:sand 2",             "default:sandstone"},
@@ -48,63 +111,7 @@ for dependency, recipes_to_add in pairs(dependent_recipes) do
 	end
 end
 
--- Defuse the default sandstone recipes, since we have
--- the compressor to take over in a more realistic manner.
-local crafts_to_clear = {
-	"default:desert_sand",
-	"default:sand",
-	"default:silver_sand",
-}
-
-local dependent_crafts_to_clear = {
-	everness = {
-		"everness:coral_sand",
-		"everness:coral_forest_deep_ocean_sand",
-		"everness:coral_white_sand",
-		"everness:crystal_sand",
-		"everness:cursed_sand",
-		"everness:cursed_lands_deep_ocean_sand",
-		"everness:crystal_forest_deep_ocean_sand",
-		"everness:mineral_sand",
-	},
-	nether = {
-		"nether:brick",
-		"nether:brick_compressed",
-	},
-}
-
-for dependency, crafts in pairs(dependent_crafts_to_clear) do
-	if minetest.get_modpath(dependency) then
-		for _, craft_entry in ipairs(crafts) do
-			table.insert(crafts_to_clear, craft_entry)
-		end
-	end
-end
-
-for _, craft_name in ipairs(crafts_to_clear) do
-	is_regular = string.sub(craft_name, 1, 7) ~= "nether:"
-
-	if is_regular then
-		-- Regular compression recipes use 2x2 shape.
-		shaped_recipe = {
-			{craft_name, craft_name},
-			{craft_name, craft_name},
-		}
-	else
-		-- Nether's compression recipes use 3x3 shape.
-		shaped_recipe = {
-			{craft_name, craft_name, craft_name},
-			{craft_name, craft_name, craft_name},
-			{craft_name, craft_name, craft_name},
-		}
-	end
-
-	minetest.clear_craft({
-		type = "shaped",
-		recipe = shaped_recipe,
-	})
-end
-
+-- Register compressor recipes
 for _, data in pairs(recipes) do
 	technic.register_compressor_recipe({input = {data[1]}, output = data[2]})
 end

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -46,16 +46,17 @@ end
 -- Clear recipes
 for _, craft_name in ipairs(crafts_to_clear) do
 	local is_regular = string.sub(craft_name, 1, 7) ~= "nether:"
+	local shaped_recipe = {}
 
 	if is_regular then
 		-- Regular compression recipes use 2x2 shape.
-		local shaped_recipe = {
+		shaped_recipe = {
 			{craft_name, craft_name},
 			{craft_name, craft_name},
 		}
 	else
 		-- Nether's compression recipes use 3x3 shape.
-		local shaped_recipe = {
+		shaped_recipe = {
 			{craft_name, craft_name, craft_name},
 			{craft_name, craft_name, craft_name},
 			{craft_name, craft_name, craft_name},

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -8,18 +8,6 @@ function technic.register_compressor_recipe(data)
 	technic.register_recipe("compressing", data)
 end
 
--- Function for cases where multiple mods exist with the same name,
--- to check if we have the right one.
-local function is_right_mod(dependency)
-	is_right = true
-
-	if dependency == "nether" then
-		is_right = minetest.registered_nodes["nether:brick_compressed"] ~= nil
-	end
-
-	return is_right
-end
-
 -- Defuse the default recipes, since we have
 -- the compressor to take over in a more realistic manner.
 local crafts_to_clear = {
@@ -48,7 +36,7 @@ local dependent_crafts_to_clear = {
 -- Add dependent recipes to main collection of
 -- recipes to be cleared if their mods are used.
 for dependency, crafts in pairs(dependent_crafts_to_clear) do
-	if minetest.get_modpath(dependency) and is_right_mod(dependency) then
+	if minetest.get_modpath(dependency) then
 		for _, craft_entry in ipairs(crafts) do
 			table.insert(crafts_to_clear, craft_entry)
 		end
@@ -116,7 +104,7 @@ local dependent_recipes = {
 -- Add dependent recipes to main recipe collection
 -- if their mods are used.
 for dependency, recipes_to_add in pairs(dependent_recipes) do
-	if minetest.get_modpath(dependency) and is_right_mod(dependency) then
+	if minetest.get_modpath(dependency) then
 		for _, recipe_entry in ipairs(recipes_to_add) do
 			table.insert(recipes, recipe_entry)
 		end

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -11,7 +11,7 @@ end
 -- Function for cases where multiple mods exist with the same name,
 -- to check if we have the right one.
 local function is_right_mod(dependency)
-	is_right = true
+	local is_right = true
 
 	if dependency == "nether" then
 		is_right = minetest.registered_nodes["nether:brick_compressed"] ~= nil

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -21,8 +21,8 @@ local recipes = {
 	{"technic:uranium35_ingot 5",  "technic:uranium_fuel"},
 }
 
-if minetest.get_modpath("everness") then
-	local everness_sand_to_sandstone_recipes = {
+local dependent_recipes = {
+	everness = {
 		{"everness:coral_deep_ocean_sand 2",          "everness:coral_deep_ocean_sandstone_block"},
 		{"everness:coral_sand 2",                     "everness:coral_sandstone"},
 		{"everness:coral_white_sand 2",               "everness:coral_white_sandstone"},
@@ -31,29 +31,27 @@ if minetest.get_modpath("everness") then
 		{"everness:cursed_lands_deep_ocean_sand 2",   "everness:cursed_lands_deep_ocean_sandstone_block"},
 		{"everness:cursed_sand 2",                    "everness:cursed_sandstone_block"},
 		{"everness:mineral_sand 2",                   "everness:mineral_sandstone"},
-	}
-
-	for _, data in ipairs(everness_sand_to_sandstone_recipes) do
-		table.insert(recipes, {data[1], data[2]})
-	end
-end
-
-if minetest.get_modpath("nether") then
-	local nether_brick_and_lump_recipes = {
+	},
+	nether = {
 		{"nether:brick 9",				"nether:brick_compressed"},
 		{"nether:brick_compressed 9",	"nether:nether_lump"},
-	}
+	},
+}
 
-	for _, data in ipairs(nether_brick_and_lump_recipes) do
-		table.insert(recipes, {data[1], data[2]})
+for dependency, recipes_to_add in pairs(dependent_recipes) do
+	if minetest.get_modpath(dependency) then
+		for _, recipe_entry in ipairs(recipes_to_add) do
+			table.insert(recipes, recipe_entry)
+		end
 	end
 end
 
--- Defuse the default sandstone recipes, since we have the compressor to take over in a more realistic manner.
+-- Defuse the default sandstone recipes, since we have
+-- the compressor to take over in a more realistic manner.
 local crafts_to_clear = {
 	"default:desert_sand",
 	"default:sand",
-	"default:silver_sand"
+	"default:silver_sand",
 }
 
 if minetest.get_modpath("everness") then

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -46,7 +46,7 @@ end
 -- Clear recipes
 for _, craft_name in ipairs(crafts_to_clear) do
 	local is_regular = string.sub(craft_name, 1, 7) ~= "nether:"
-	local shaped_recipe = {}
+	local shaped_recipe
 
 	if is_regular then
 		-- Regular compression recipes use 2x2 shape.

--- a/technic/machines/register/compressor_recipes.lua
+++ b/technic/machines/register/compressor_recipes.lua
@@ -45,17 +45,17 @@ end
 
 -- Clear recipes
 for _, craft_name in ipairs(crafts_to_clear) do
-	is_regular = string.sub(craft_name, 1, 7) ~= "nether:"
+	local is_regular = string.sub(craft_name, 1, 7) ~= "nether:"
 
 	if is_regular then
 		-- Regular compression recipes use 2x2 shape.
-		shaped_recipe = {
+		local shaped_recipe = {
 			{craft_name, craft_name},
 			{craft_name, craft_name},
 		}
 	else
 		-- Nether's compression recipes use 3x3 shape.
-		shaped_recipe = {
+		local shaped_recipe = {
 			{craft_name, craft_name, craft_name},
 			{craft_name, craft_name, craft_name},
 			{craft_name, craft_name, craft_name},

--- a/technic/mod.conf
+++ b/technic/mod.conf
@@ -1,3 +1,3 @@
 name = technic
 depends = default, pipeworks, technic_worldgen, basic_materials
-optional_depends = bucket, screwdriver, mesecons, mesecons_mvps, digilines, digiline_remote, intllib, unified_inventory, vector_extras, dye, craftguide, i3, everness
+optional_depends = bucket, screwdriver, mesecons, mesecons_mvps, digilines, digiline_remote, intllib, unified_inventory, vector_extras, dye, craftguide, i3, everness, nether


### PR DESCRIPTION
Hi,

Another addition with nether, similar to the previous one, just this time for compressor.

Clears nether's default recipes for compressed nether brick and nether lump, using the compressor instead for these tasks.

+ did the same type of clearing up for better overview as with the grinder recipes in the other MR.