### PR TITLE
Expose get/set charge functions

### DIFF
--- a/technic/doc/api.md
+++ b/technic/doc/api.md
@@ -160,6 +160,11 @@ Unsorted functions:
 	* If `technic.power_tools[itemstack:get_name()]` is `nil` (or `false`), this
 	  function does nothing, else that value is the maximum charge.
 	* The itemstack metadata is changed to contain the charge.
+* `technic.get_charge(itemstack)`
+	* Returns the charge and max charge of the given itemstack.
+	* If the itemstack is not an RE chargeable item, both return values will be zero.
+* `technic.set_charge(itemstack, charge)`
+	* Modifies the charge of the given itemstack.
 
 ### Node-specific
 * `technic.get_or_load_node(pos)`

--- a/technic/machines/register/battery_box.lua
+++ b/technic/machines/register/battery_box.lua
@@ -409,7 +409,7 @@ minetest.register_on_player_receive_fields(
 	end
 )
 
-local function default_get_charge(itemstack)
+function technic.get_charge(itemstack)
 	-- check if is chargable
 	local tool_name = itemstack:get_name()
 	if not technic.power_tools[tool_name] then
@@ -419,7 +419,7 @@ local function default_get_charge(itemstack)
 	return item_meta:get_int("technic:charge"), technic.power_tools[tool_name]
 end
 
-local function default_set_charge(itemstack, charge)
+function technic.set_charge(itemstack, charge)
 	local tool_name = itemstack:get_name()
 	if technic.power_tools[tool_name] then
 		technic.set_RE_wear(itemstack, charge, technic.power_tools[tool_name])
@@ -437,8 +437,8 @@ function technic.charge_tools(meta, batt_charge, charge_step)
 
 	-- get callbacks
 	local src_def = src_stack:get_definition()
-	local technic_get_charge = src_def.technic_get_charge or default_get_charge
-	local technic_set_charge = src_def.technic_set_charge or default_set_charge
+	local technic_get_charge = src_def.technic_get_charge or technic.get_charge
+	local technic_set_charge = src_def.technic_set_charge or technic.set_charge
 
 	-- get tool charge
 	local tool_charge, item_max_charge = technic_get_charge(src_stack)
@@ -471,8 +471,8 @@ function technic.discharge_tools(meta, batt_charge, charge_step, max_charge)
 
 	-- get callbacks
 	local src_def = src_stack:get_definition()
-	local technic_get_charge = src_def.technic_get_charge or default_get_charge
-	local technic_set_charge = src_def.technic_set_charge or default_set_charge
+	local technic_get_charge = src_def.technic_get_charge or technic.get_charge
+	local technic_set_charge = src_def.technic_set_charge or technic.set_charge
 
 	-- get tool charge
 	local tool_charge, item_max_charge = technic_get_charge(src_stack)


### PR DESCRIPTION
Exposes the battery box's get/set charge functions, for easier compatibility with other mods and other versions of technic.