### PR TITLE
power multiplication fix

### DIFF
--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -43,6 +43,8 @@ local function check_connections(pos)
 	return connections
 end
 
+local clear_networks
+
 local function clear_network(net)
 	for _,v in pairs(technic.networks[net].all_nodes) do
 		local pos1 = minetest.hash_node_position(v)
@@ -62,7 +64,7 @@ local function clear_network(net)
 	end
 end
 
-local function clear_networks(pos)
+clear_networks = function(pos)
 	local node = minetest.get_node(pos)
 	local meta = minetest.get_meta(pos)
 	local placed = node.name ~= "air"

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -45,13 +45,17 @@ end
 
 local clear_networks
 
-local function clear_network(net)
-	for _,v in pairs(technic.networks[net].all_nodes) do
+local function clear_network(network_id)
+	if not network_id then
+		return
+	end
+
+	for _,v in pairs(technic.networks[network_id].all_nodes) do
 		local pos1 = minetest.hash_node_position(v)
 		technic.cables[pos1] = nil
 	end
-	local network_bckup = technic.networks[net]
-	technic.networks[net] = nil
+	local network_bckup = technic.networks[network_id]
+	technic.networks[network_id] = nil
 
 	for _,n_pos in pairs(network_bckup.PR_nodes) do
 		clear_networks(n_pos)
@@ -86,7 +90,6 @@ clear_networks = function(pos)
 
 			-- Actually add it to the (cached) network
 			-- !! IMPORTANT: ../switching_station.lua -> check_node_subp() must be kept in sync
-			pos.visited = 1
 			if technic.is_tier_cable(node.name, tier) then
 				technic.cables[minetest.hash_node_position(pos)] = network_id
 				table.insert(network.all_nodes,pos)
@@ -134,17 +137,12 @@ clear_networks = function(pos)
 		return
 	end
 
-	local net = technic.cables[minetest.hash_node_position(pos)]
-	if net and technic.networks[net] then
-		clear_network(net)
-	end
+	clear_network(technic.cables[minetest.hash_node_position(pos)])
 
 	for _,connected_pos in pairs(positions) do
-		local net = technic.cables[minetest.hash_node_position(connected_pos)]
-		if net and technic.networks[net] then
-			-- Not a dead end, so the whole network needs to be recalculated
-			clear_network(net)
-		end
+		local network_id = technic.cables[minetest.hash_node_position(connected_pos)]
+		-- Not a dead end, so the whole network needs to be recalculated
+		clear_network(network_id)
 	end
 end
 

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -43,7 +43,7 @@ local function check_connections(pos)
 	return connections
 end
 
-local function clear_networks(pos)
+function technic.clear_networks(pos)
 	local node = minetest.get_node(pos)
 	local meta = minetest.get_meta(pos)
 	local placed = node.name ~= "air"
@@ -77,6 +77,7 @@ local function clear_networks(pos)
 					-- Found a machine
 					local eu_type = technic.machines[tier][node.name]
 					meta:set_string(tier.."_network", string.format("%.20g", network_id))
+					meta:set_int(tier.."_EU_timeout", 2)
 					if     eu_type == technic.producer then
 						table.insert(network.PR_nodes, pos)
 					elseif eu_type == technic.receiver then
@@ -169,8 +170,8 @@ function technic.register_cable(tier, size)
 		node_box = node_box,
 		connects_to = {"group:technic_"..ltier.."_cable",
 			"group:technic_"..ltier, "group:technic_all_tiers"},
-		on_construct = clear_networks,
-		on_destruct = clear_networks,
+		on_construct = technic.clear_networks,
+		on_destruct = technic.clear_networks,
 	})
 
 	local xyz = {
@@ -209,8 +210,8 @@ function technic.register_cable(tier, size)
 			node_box = table.copy(node_box),
 			connects_to = {"group:technic_"..ltier.."_cable",
 				"group:technic_"..ltier, "group:technic_all_tiers"},
-			on_construct = clear_networks,
-			on_destruct = clear_networks,
+			on_construct = technic.clear_networks,
+			on_destruct = technic.clear_networks,
 		}
 		def.node_box.fixed = {
 			{-size, -size, -size, size, size, size},
@@ -295,7 +296,7 @@ end
 local function clear_nets_if_machine(pos, node)
 	for tier, machine_list in pairs(technic.machines) do
 		if machine_list[node.name] ~= nil then
-			return clear_networks(pos)
+			return technic.clear_networks(pos)
 		end
 	end
 end

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -64,7 +64,6 @@ end
 
 function technic.clear_networks(pos)
 	local node = minetest.get_node(pos)
-	core.log(node.name)
 	local meta = minetest.get_meta(pos)
 	local placed = node.name ~= "air"
 	local positions = check_connections(pos)

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -52,17 +52,17 @@ local function clear_network(net)
 	technic.networks[net] = nil
 
 	for _,n_pos in pairs(network_bckup.PR_nodes) do
-		technic.clear_networks(n_pos)
+		clear_networks(n_pos)
 	end
 	for _,n_pos in pairs(network_bckup.RE_nodes) do
-		technic.clear_networks(n_pos)
+		clear_networks(n_pos)
 	end
 	for _,n_pos in pairs(network_bckup.BA_nodes) do
-		technic.clear_networks(n_pos)
+		clear_networks(n_pos)
 	end
 end
 
-function technic.clear_networks(pos)
+local function clear_networks(pos)
 	local node = minetest.get_node(pos)
 	local meta = minetest.get_meta(pos)
 	local placed = node.name ~= "air"
@@ -191,8 +191,8 @@ function technic.register_cable(tier, size)
 		node_box = node_box,
 		connects_to = {"group:technic_"..ltier.."_cable",
 			"group:technic_"..ltier, "group:technic_all_tiers"},
-		on_construct = technic.clear_networks,
-		after_destruct = technic.clear_networks,
+		on_construct = clear_networks,
+		after_destruct = clear_networks,
 	})
 
 	local xyz = {
@@ -231,8 +231,8 @@ function technic.register_cable(tier, size)
 			node_box = table.copy(node_box),
 			connects_to = {"group:technic_"..ltier.."_cable",
 				"group:technic_"..ltier, "group:technic_all_tiers"},
-			on_construct = technic.clear_networks,
-			after_destruct = technic.clear_networks,
+			on_construct = clear_networks,
+			after_destruct = clear_networks,
 		}
 		def.node_box.fixed = {
 			{-size, -size, -size, size, size, size},
@@ -317,7 +317,7 @@ end
 local function clear_nets_if_machine(pos, node)
 	for tier, machine_list in pairs(technic.machines) do
 		if machine_list[node.name] ~= nil then
-			return technic.clear_networks(pos)
+			return clear_networks(pos)
 		end
 	end
 end

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -68,10 +68,9 @@ function technic.clear_networks(pos)
 
 				-- Actually add it to the (cached) network
 				-- !! IMPORTANT: ../switching_station.lua -> check_node_subp() must be kept in sync
-				technic.cables[minetest.hash_node_position(pos)] = network_id
 				pos.visited = 1
 				if technic.is_tier_cable(node.name, tier) then
-					-- Found a cable
+					technic.cables[minetest.hash_node_position(pos)] = network_id
 					table.insert(network.all_nodes,pos)
 				elseif technic.machines[tier][node.name] then
 					-- Found a machine

--- a/technic/machines/register/cables.lua
+++ b/technic/machines/register/cables.lua
@@ -43,83 +43,106 @@ local function check_connections(pos)
 	return connections
 end
 
+local function clear_network(net)
+	for _,v in pairs(technic.networks[net].all_nodes) do
+		local pos1 = minetest.hash_node_position(v)
+		technic.cables[pos1] = nil
+	end
+	local network_bckup = technic.networks[net]
+	technic.networks[net] = nil
+
+	for _,n_pos in pairs(network_bckup.PR_nodes) do
+		technic.clear_networks(n_pos)
+	end
+	for _,n_pos in pairs(network_bckup.RE_nodes) do
+		technic.clear_networks(n_pos)
+	end
+	for _,n_pos in pairs(network_bckup.BA_nodes) do
+		technic.clear_networks(n_pos)
+	end
+end
+
 function technic.clear_networks(pos)
 	local node = minetest.get_node(pos)
+	core.log(node.name)
 	local meta = minetest.get_meta(pos)
 	local placed = node.name ~= "air"
 	local positions = check_connections(pos)
+
 	if #positions < 1 then return end
-	local dead_end = #positions == 1
-	for _,connected_pos in pairs(positions) do
-		local net = technic.cables[minetest.hash_node_position(connected_pos)]
-		if net and technic.networks[net] then
-			if dead_end and placed then
-				-- Dead end placed, add it to the network
-				-- Get the network
-				local network_id = technic.cables[minetest.hash_node_position(positions[1])]
-				if not network_id then
-					-- We're evidently not on a network, nothing to add ourselves to
-					return
-				end
-				local sw_pos = minetest.get_position_from_hash(network_id)
-				sw_pos.y = sw_pos.y + 1
-				local network = technic.networks[network_id]
-				local tier = network.tier
 
-				-- Actually add it to the (cached) network
-				-- !! IMPORTANT: ../switching_station.lua -> check_node_subp() must be kept in sync
-				pos.visited = 1
-				if technic.is_tier_cable(node.name, tier) then
-					technic.cables[minetest.hash_node_position(pos)] = network_id
-					table.insert(network.all_nodes,pos)
-				elseif technic.machines[tier][node.name] then
-					-- Found a machine
-					local eu_type = technic.machines[tier][node.name]
-					meta:set_string(tier.."_network", string.format("%.20g", network_id))
-					meta:set_int(tier.."_EU_timeout", 2)
-					if     eu_type == technic.producer then
-						table.insert(network.PR_nodes, pos)
-					elseif eu_type == technic.receiver then
-						table.insert(network.RE_nodes, pos)
-					elseif eu_type == technic.producer_receiver then
-						table.insert(network.PR_nodes, pos)
-						table.insert(network.RE_nodes, pos)
-					elseif eu_type == technic.battery then
-						table.insert(network.BA_nodes, pos)
-					end
-					-- Note: SPECIAL (i.e. switching station) is not traversed!
-				end
-			elseif dead_end and not placed then
-				-- Dead end removed, remove it from the network
-				-- Get the network
-				local network_id = technic.cables[minetest.hash_node_position(positions[1])]
-				if not network_id then
-					-- We're evidently not on a network, nothing to add ourselves to
-					return
-				end
-				local network = technic.networks[network_id]
+	if #positions == 1 then
+		if placed then
+			-- Dead end placed, add it to the network
+			-- Get the network
+			local network_id = technic.cables[minetest.hash_node_position(positions[1])]
+			if not network_id then
+				-- We're evidently not on a network, nothing to add ourselves to
+				return
+			end
+			local network = technic.networks[network_id]
+			local tier = network.tier
 
-				-- Search for and remove machine
-				technic.cables[minetest.hash_node_position(pos)] = nil
-				for tblname,table in pairs(network) do
-					if tblname ~= "tier" then
-						for machinenum,machine in pairs(table) do
-							if machine.x == pos.x
-							and machine.y == pos.y
-							and machine.z == pos.z then
-								table[machinenum] = nil
-							end
+			-- Actually add it to the (cached) network
+			-- !! IMPORTANT: ../switching_station.lua -> check_node_subp() must be kept in sync
+			pos.visited = 1
+			if technic.is_tier_cable(node.name, tier) then
+				technic.cables[minetest.hash_node_position(pos)] = network_id
+				table.insert(network.all_nodes,pos)
+			elseif technic.machines[tier][node.name] then
+				-- Found a machine
+				local eu_type = technic.machines[tier][node.name]
+				meta:set_string(tier.."_network", string.format("%.20g", network_id))
+				meta:set_int(tier.."_EU_timeout", 2)
+				if     eu_type == technic.producer then
+					table.insert(network.PR_nodes, pos)
+				elseif eu_type == technic.receiver then
+					table.insert(network.RE_nodes, pos)
+				elseif eu_type == technic.producer_receiver then
+					table.insert(network.PR_nodes, pos)
+					table.insert(network.RE_nodes, pos)
+				elseif eu_type == technic.battery then
+					table.insert(network.BA_nodes, pos)
+				end
+				-- Note: SPECIAL (i.e. switching station) is not traversed!
+			end
+		else
+			-- Dead end removed, remove it from the network
+			-- Get the network
+			local network_id = technic.cables[minetest.hash_node_position(positions[1])]
+			if not network_id then
+				-- We're evidently not on a network, nothing to add ourselves to
+				return
+			end
+			local network = technic.networks[network_id]
+
+			-- Search for and remove machine
+			technic.cables[minetest.hash_node_position(pos)] = nil
+			for tblname,table in pairs(network) do
+				if tblname ~= "tier" then
+					for machinenum,machine in pairs(table) do
+						if machine.x == pos.x
+						and machine.y == pos.y
+						and machine.z == pos.z then
+							table[machinenum] = nil
 						end
 					end
 				end
-			else
-				-- Not a dead end, so the whole network needs to be recalculated
-				for _,v in pairs(technic.networks[net].all_nodes) do
-					local pos1 = minetest.hash_node_position(v)
-					technic.cables[pos1] = nil
-				end
-				technic.networks[net] = nil
 			end
+		end
+		return
+	end
+
+	local net = technic.cables[minetest.hash_node_position(pos)]
+	if net and technic.networks[net] then
+		clear_network(net)
+	end
+
+	for _,connected_pos in pairs(positions) do
+		local net = technic.cables[minetest.hash_node_position(connected_pos)]
+		if net and technic.networks[net] then
+			-- Not a dead end, so the whole network needs to be recalculated
+			clear_network(net)
 		end
 	end
 end
@@ -170,7 +193,7 @@ function technic.register_cable(tier, size)
 		connects_to = {"group:technic_"..ltier.."_cable",
 			"group:technic_"..ltier, "group:technic_all_tiers"},
 		on_construct = technic.clear_networks,
-		on_destruct = technic.clear_networks,
+		after_destruct = technic.clear_networks,
 	})
 
 	local xyz = {
@@ -210,7 +233,7 @@ function technic.register_cable(tier, size)
 			connects_to = {"group:technic_"..ltier.."_cable",
 				"group:technic_"..ltier, "group:technic_all_tiers"},
 			on_construct = technic.clear_networks,
-			on_destruct = technic.clear_networks,
+			after_destruct = technic.clear_networks,
 		}
 		def.node_box.fixed = {
 			{-size, -size, -size, size, size, size},

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -100,9 +100,11 @@ end
 -- Add a wire node to the LV/MV/HV network
 -- Returns: indicator whether the cable is new in the network
 local hash_node_position = minetest.hash_node_position
-local function add_network_node(nodes, pos, network_id)
+local function add_network_node(nodes, pos, network_id, cable)
 	local node_id = hash_node_position(pos)
-	technic.cables[node_id] = network_id
+	if cable then
+		technic.cables[node_id] = network_id
+	end
 	if nodes[node_id] then
 		return false
 	end
@@ -111,7 +113,7 @@ local function add_network_node(nodes, pos, network_id)
 end
 
 local function add_cable_node(nodes, pos, network_id, queue)
-	if add_network_node(nodes, pos, network_id) then
+	if add_network_node(nodes, pos, network_id, true) then
 		queue[#queue + 1] = pos
 	end
 end
@@ -149,18 +151,18 @@ local check_node_subp = function(network, pos, machines, sw_pos, from_below, net
 	end
 
 	if     eu_type == technic.producer then
-		add_network_node(network.PR_nodes, pos, network_id)
+		add_network_node(network.PR_nodes, pos, network_id, false)
 	elseif eu_type == technic.receiver then
-		add_network_node(network.RE_nodes, pos, network_id)
+		add_network_node(network.RE_nodes, pos, network_id, false)
 	elseif eu_type == technic.producer_receiver then
-		add_network_node(network.PR_nodes, pos, network_id)
-		add_network_node(network.RE_nodes, pos, network_id)
+		add_network_node(network.PR_nodes, pos, network_id, false)
+		add_network_node(network.RE_nodes, pos, network_id, false)
 	elseif eu_type == technic.battery then
-		add_network_node(network.BA_nodes, pos, network_id)
+		add_network_node(network.BA_nodes, pos, network_id, false)
 	elseif eu_type == "SPECIAL" and from_below and
 			not vector.equals(pos, sw_pos) then
 		-- Another switching station -> disable it
-		add_network_node(network.SP_nodes, pos, network_id)
+		add_network_node(network.SP_nodes, pos, network_id, false)
 		meta:set_int("active", 0)
 	end
 

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -97,12 +97,12 @@ local function flatten(map)
 	return list
 end
 
--- Add a wire node to the LV/MV/HV network
--- Returns: indicator whether the cable is new in the network
+-- Add a node to the LV/MV/HV network
+-- Returns: indicator whether the node is new in the network
 local hash_node_position = minetest.hash_node_position
-local function add_network_node(nodes, pos, network_id, cable)
+local function add_network_node(nodes, pos, network_id)
 	local node_id = hash_node_position(pos)
-	if cable then
+	if network_id then
 		technic.cables[node_id] = network_id
 	end
 	if nodes[node_id] then
@@ -113,7 +113,7 @@ local function add_network_node(nodes, pos, network_id, cable)
 end
 
 local function add_cable_node(nodes, pos, network_id, queue)
-	if add_network_node(nodes, pos, network_id, true) then
+	if add_network_node(nodes, pos, network_id) then
 		queue[#queue + 1] = pos
 	end
 end
@@ -151,18 +151,18 @@ local check_node_subp = function(network, pos, machines, sw_pos, from_below, net
 	end
 
 	if     eu_type == technic.producer then
-		add_network_node(network.PR_nodes, pos, network_id, false)
+		add_network_node(network.PR_nodes, pos)
 	elseif eu_type == technic.receiver then
-		add_network_node(network.RE_nodes, pos, network_id, false)
+		add_network_node(network.RE_nodes, pos)
 	elseif eu_type == technic.producer_receiver then
-		add_network_node(network.PR_nodes, pos, network_id, false)
-		add_network_node(network.RE_nodes, pos, network_id, false)
+		add_network_node(network.PR_nodes, pos)
+		add_network_node(network.RE_nodes, pos)
 	elseif eu_type == technic.battery then
-		add_network_node(network.BA_nodes, pos, network_id, false)
+		add_network_node(network.BA_nodes, pos)
 	elseif eu_type == "SPECIAL" and from_below and
 			not vector.equals(pos, sw_pos) then
 		-- Another switching station -> disable it
-		add_network_node(network.SP_nodes, pos, network_id, false)
+		add_network_node(network.SP_nodes, pos)
 		meta:set_int("active", 0)
 	end
 
@@ -205,7 +205,6 @@ local get_network = function(sw_pos, cable_pos, tier)
 		end
 		return cached.PR_nodes, cached.BA_nodes, cached.RE_nodes
 	end
-
 	local machines = technic.machines[tier]
 	local network = {
 		tier = tier,
@@ -495,7 +494,6 @@ minetest.register_abm({
 				if nodedef and nodedef.technic_on_disable then
 					nodedef.technic_on_disable(pos, node)
 				end
-				technic.clear_networks(pos)
 			end
 		end
 	end,

--- a/technic/machines/switching_station.lua
+++ b/technic/machines/switching_station.lua
@@ -181,7 +181,7 @@ local traverse_network = function(network, pos, machines, sw_pos, network_id, qu
 	end
 end
 
-local touch_nodes = function(list, tier, network_id)
+local touch_nodes = function(list, tier)
 	for _, pos in ipairs(list) do
 		local meta = minetest.get_meta(pos)
 		meta:set_int(tier.."_EU_timeout", 2) -- Touch node
@@ -193,9 +193,9 @@ local get_network = function(sw_pos, cable_pos, tier)
 	local cached = technic.networks[network_id]
 	if cached and cached.tier == tier then
 		-- Re-use cached system data
-		touch_nodes(cached.PR_nodes, tier, network_id)
-		touch_nodes(cached.BA_nodes, tier, network_id)
-		touch_nodes(cached.RE_nodes, tier, network_id)
+		touch_nodes(cached.PR_nodes, tier)
+		touch_nodes(cached.BA_nodes, tier)
+		touch_nodes(cached.RE_nodes, tier)
 		for _, pos in ipairs(cached.SP_nodes) do
 			-- Disable all other switching stations (again)
 			local meta = minetest.get_meta(pos)


### PR DESCRIPTION
Fixed power multiplication bug. Resolves #277. The cause of the bug was that machines can be a part of multiple networks and generate power for each of the networks. This was fixed by checking if machine is already part of an other network and not making it a part of the current one. When network times out the network meta string value is cleared and the clear_networks function is used to try to connect the machine to a different network.