### PR TITLE
Manual: Use lead OR stainless steel in reactors

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -1076,13 +1076,14 @@ power cable must connect to draw off the generated power.
 The reactor structure consists of concentric layers, each a cubical
 shell, around the core.  Immediately around the core is a layer of water,
 representing the reactor coolant; water blocks may be either source blocks
-or flowing blocks.  Around that is a layer of stainless steel blocks,
-representing the reactor pressure vessel, and around that a layer of
-blast-resistant concrete blocks, representing a containment structure.
+or flowing blocks.  Around that is a layer of stainless steel or lead
+blocks, representing the reactor pressure vessel, and around that a layer
+of blast-resistant concrete blocks, representing a containment structure.
 It is customary, though no longer mandatory, to surround this with a
 layer of ordinary concrete blocks.  The mandatory reactor structure
 makes a 7&times;7&times;7 cube, and the full customary structure a
-9&times;9&times;9 cube.
+9&times;9&times;9 cube.  If you use stainless steel blocks, they will be
+converted to lead blocks.
 
 The layers surrounding the core don't have to be absolutely complete.
 Indeed, if they were complete, it would be impossible to cable the core to

--- a/manual.md
+++ b/manual.md
@@ -1076,14 +1076,14 @@ power cable must connect to draw off the generated power.
 The reactor structure consists of concentric layers, each a cubical
 shell, around the core.  Immediately around the core is a layer of water,
 representing the reactor coolant; water blocks may be either source blocks
-or flowing blocks.  Around that is a layer of stainless steel or lead
-blocks, representing the reactor pressure vessel, and around that a layer
-of blast-resistant concrete blocks, representing a containment structure.
-It is customary, though no longer mandatory, to surround this with a
-layer of ordinary concrete blocks.  The mandatory reactor structure
-makes a 7&times;7&times;7 cube, and the full customary structure a
-9&times;9&times;9 cube.  If you use stainless steel blocks, they will be
-converted to lead blocks.
+or flowing blocks.  Around that is a layer of lead blocks, representing
+the reactor pressure vessel, and around that a layer of blast-resistant
+concrete blocks, representing a containment structure. It is customary,
+though no longer mandatory, to surround this with a layer of ordinary
+concrete blocks.  The mandatory reactor structure makes a
+7&times;7&times;7 cube, and the full customary structure a
+9&times;9&times;9 cube.  Stainless steel blocks can be used in place of
+lead blocks, but this may be deprecated in the future.
 
 The layers surrounding the core don't have to be absolutely complete.
 Indeed, if they were complete, it would be impossible to cable the core to


### PR DESCRIPTION
Because the mod will convert stainless steel into lead, tell people about the option and warn them about the change. This will mitigate #656 until a decision is made about conversion.